### PR TITLE
fix(infra): fix Docker bundling failures on x86_64 build hosts

### DIFF
--- a/packages/infra/src/stacks/lance-service-stack.ts
+++ b/packages/infra/src/stacks/lance-service-stack.ts
@@ -53,14 +53,17 @@ export class LanceServiceStack extends Stack {
           LANCEDB_LOCK_TABLE_NAME: lancedbLockTableName,
         },
         bundling: {
+          dockerOptions: {
+            user: 'root',
+          },
           commandHooks: {
             beforeBundling(): string[] {
               return [
                 'apt-get update -qq && apt-get install -y -qq protobuf-compiler > /dev/null 2>&1',
               ];
             },
-            afterBundling(): string[] {
-              return [];
+            afterBundling(_inputDir: string, outputDir: string): string[] {
+              return [`chown -R 1000:1000 ${outputDir}`];
             },
           },
         },

--- a/packages/infra/src/stacks/ocr-stack.ts
+++ b/packages/infra/src/stacks/ocr-stack.ts
@@ -179,7 +179,10 @@ export class OcrStack extends Stack {
             ];
           },
           afterBundling(inputDir: string, outputDir: string): string[] {
-            return [`cp -r ${inputDir}/models ${outputDir}/models`];
+            return [
+              `cp -r ${inputDir}/models ${outputDir}/models`,
+              `chown -R 1000:1000 ${outputDir}`,
+            ];
           },
         },
       },

--- a/packages/infra/src/stacks/workflow-stack.ts
+++ b/packages/infra/src/stacks/workflow-stack.ts
@@ -542,10 +542,11 @@ export class WorkflowStack extends Stack {
         {
           bundling: {
             image: lambda.Runtime.PYTHON_3_14.bundlingImage,
+            platform: 'linux/arm64',
             command: [
               'bash',
               '-c',
-              'pip install pypdfium2 -t /asset-output && cp -r /asset-input/* /asset-output/',
+              'pip install pypdfium2 --platform manylinux2014_aarch64 --only-binary=:all: -t /asset-output && cp -r /asset-input/* /asset-output/',
             ],
           },
         },


### PR DESCRIPTION
## Summary
- **lance-service-stack**: Add `dockerOptions.user='root'` for `apt-get` and `chown` output dir to fix CDK cleanup permission error
- **ocr-stack**: Add `chown` in `afterBundling` to fix CDK cleanup after root-owned Docker build artifacts
- **workflow-stack**: Add `platform: 'linux/arm64'` and pip `--platform manylinux2014_aarch64` flag to install ARM64-compatible `pypdfium2` binary for Lambda

## Problem
When deploying from an **x86_64 build host**, three issues occur:

1. `LanceServiceStack` - `beforeBundling` runs `apt-get` but Docker container runs as non-root (uid 1000), causing permission denied
2. `OcrStack` - Docker builds as root, creating root-owned files in the output dir that CDK cannot clean up (`EACCES: permission denied, unlink`)
3. `WorkflowStack` - `pypdfium2` is installed via pip inside an x86_64 Docker image, but the Lambda runs on ARM64. The `libpdfium.so` binary fails to load at runtime with `OSError: cannot open shared object file`

## Test plan
- [ ] Deploy from x86_64 host: `cdk deploy IDP-V2-LanceService` succeeds without permission errors
- [ ] Deploy from x86_64 host: `cdk deploy IDP-V2-Ocr` succeeds and CDK cleanup works
- [ ] Upload a PDF document via UI: OCR orchestrator Lambda processes without `libpdfium.so` error