### PR TITLE
Fix MCP stack deploy order dependency

### DIFF
--- a/packages/common/constructs/src/app/mcp/search-mcp.ts
+++ b/packages/common/constructs/src/app/mcp/search-mcp.ts
@@ -1,4 +1,4 @@
-import { Duration } from 'aws-cdk-lib';
+import { ArnFormat, Duration, Stack } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime, Architecture } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -29,10 +29,12 @@ export class SearchMcp extends Construct {
       SSM_KEYS.LANCE_SERVICE_FUNCTION_ARN,
     );
 
-    const graphServiceFunctionArn = StringParameter.valueForStringParameter(
-      this,
-      SSM_KEYS.GRAPH_SERVICE_FUNCTION_ARN,
-    );
+    const graphServiceFunctionArn = Stack.of(this).formatArn({
+      service: 'lambda',
+      resource: 'function',
+      resourceName: 'idp-v2-graph-service',
+      arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+    });
 
     this.function = new NodejsFunction(this, 'Function', {
       entry: path.resolve(


### PR DESCRIPTION
  - search-mcp에서 graph-service ARN을 SSM 조회 대신 Stack.formatArn으로 직접 구성
  - 새 환경 배포 시 WorkflowStack보다 McpStack이 먼저 배포되어 SSM 파라미터 없음 에러 해결
