### PR TITLE
fix(deps): patch @xmldom/xmldom CVE by overriding to >=0.8.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
       "h3": ">=1.15.6",
       "handlebars": ">=4.7.9",
       "picomatch": ">=4.0.4",
-      "path-to-regexp": ">=0.1.13"
+      "path-to-regexp": ">=0.1.13",
+      "@xmldom/xmldom": ">=0.8.12 <0.9.0"
     },
     "onlyBuiltDependencies": [
       "duckdb"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   handlebars: '>=4.7.9'
   picomatch: '>=4.0.4'
   path-to-regexp: '>=0.1.13'
+  '@xmldom/xmldom': '>=0.8.12 <0.9.0'
 
 importers:
 
@@ -4904,10 +4905,9 @@ packages:
     resolution: {integrity: sha512-siPY6BD5dQ2SZPl3I0OZBHL27ZqZvLEosObsZRQ1NUB8qcxegwt0T9eKtV96JMFQpIz1elhkzqOg4c/Ri6Dp9A==}
     engines: {node: ^14.14.0 || >=16.0.0}
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+  '@xmldom/xmldom@0.8.12':
+    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -17411,7 +17411,7 @@ snapshots:
     dependencies:
       arch: 3.0.0
 
-  '@xmldom/xmldom@0.8.11': {}
+  '@xmldom/xmldom@0.8.12': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -21704,7 +21704,7 @@ snapshots:
 
   mammoth@1.12.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.8.12
       argparse: 1.0.10
       base64-js: 1.5.1
       bluebird: 3.4.7


### PR DESCRIPTION
## Summary
- Patch @xmldom/xmldom CDATA injection vulnerability (CVE) by overriding transitive dependency from 0.8.11 to >=0.8.12 <0.9.0
- Affected path: mammoth 1.12.0 → @xmldom/xmldom 0.8.11

## Test plan
- [x] Verified `@xmldom/xmldom@0.8.12` is resolved via `npm ls @xmldom/xmldom`
- [ ] Confirm existing tests pass