### PR TITLE
Remove pip install from skill SKILL.md files

### DIFF
--- a/packages/agents/idp-agent/.skills/chart/SKILL.md
+++ b/packages/agents/idp-agent/.skills/chart/SKILL.md
@@ -8,6 +8,7 @@ description: "Data chart and graph creation skill using Matplotlib. Use when the
 ## Execution Rules
 
 - **ALL code execution MUST use the `code_interpreter` tool.** Do NOT use the `shell` tool.
+- **NEVER call `!pip install`.** `matplotlib`, `numpy`, `pandas`, `boto3`, `Pillow` are pre-installed in the AgentCore Code Interpreter sandbox. Import directly. If an import fails, stop and report the error to the user — do not attempt to install anything.
 - **Generate the chart and upload to S3 in a SINGLE `code_interpreter` call.** Do NOT split into multiple calls.
 - Before calling `code_interpreter`, call `artifact_path(filename="chart.png")` to get the S3 bucket and key.
 - After completion, report the `artifact_ref` to the user.
@@ -429,7 +430,4 @@ When creating charts for embedding, save the image locally first, then reference
 
 ## Dependencies
 
-All dependencies should be installed within code_interpreter:
-```python
-!pip install matplotlib numpy
-```
+`matplotlib`, `numpy`, `pandas`, `boto3`, `Pillow` are pre-installed in the Code Interpreter sandbox. Do NOT call `!pip install` — import directly.

--- a/packages/agents/idp-agent/.skills/docx/SKILL.md
+++ b/packages/agents/idp-agent/.skills/docx/SKILL.md
@@ -8,6 +8,7 @@ description: "Word document (.docx) creation, editing, reading, and manipulation
 ## Execution Rules
 
 - **ALL code execution MUST use the `code_interpreter` tool.** Do NOT use the `shell` tool.
+- **NEVER call `!pip install`.** `python-docx`, `boto3`, `pandas`, `openpyxl`, `Pillow`, `matplotlib`, `numpy`, `requests`, `lxml` are pre-installed in the AgentCore Code Interpreter sandbox. Import directly. If an import fails, stop and report the error to the user — do not attempt to install anything.
 - **Generate the COMPLETE document and upload to S3 in a SINGLE `code_interpreter` call.** Do NOT split into multiple calls.
 - Before calling `code_interpreter`, call `artifact_path(filename="report.docx")` to get the S3 bucket and key.
 - After completion, report the `artifact_ref` to the user.
@@ -20,8 +21,6 @@ description: "Word document (.docx) creation, editing, reading, and manipulation
 3. Call `code_interpreter` ONCE with a single script that does everything: create the document, save it, and upload to S3.
 
 ```python
-!pip install python-docx
-
 from docx import Document
 import boto3
 
@@ -88,8 +87,6 @@ Only fall back to the `chart` skill if a standalone chart artifact is explicitly
 Read .docx files by downloading from the given S3 path and using `python-docx` in `code_interpreter`.
 
 ```python
-!pip install python-docx
-
 import boto3
 from docx import Document
 from io import BytesIO
@@ -116,8 +113,6 @@ Generate .docx files with `python-docx` in code_interpreter.
 
 ### Setup
 ```python
-!pip install python-docx
-
 from docx import Document
 from docx.shared import Inches, Pt, Cm, RGBColor
 from docx.enum.text import WD_ALIGN_PARAGRAPH
@@ -437,7 +432,4 @@ Without the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty pa
 
 ## Dependencies
 
-All dependencies should be installed within code_interpreter:
-```python
-!pip install python-docx
-```
+`python-docx`, `boto3`, `Pillow`, `lxml`, `matplotlib`, `requests` are pre-installed in the Code Interpreter sandbox. Do NOT call `!pip install` — import directly.

--- a/packages/agents/idp-agent/.skills/pptx/SKILL.md
+++ b/packages/agents/idp-agent/.skills/pptx/SKILL.md
@@ -8,6 +8,7 @@ description: "PowerPoint presentation (.pptx) creation, editing, reading, and ma
 ## Execution Rules
 
 - **ALL code execution MUST use the `code_interpreter` tool.** Do NOT use the `shell` tool.
+- **NEVER call `!pip install`.** `python-pptx`, `boto3`, `Pillow`, `lxml`, `matplotlib`, `numpy`, `requests`, `markitdown` are pre-installed in the AgentCore Code Interpreter sandbox. Import directly. If an import fails, stop and report the error to the user — do not attempt to install anything.
 - **Generate the COMPLETE presentation and upload to S3 in a SINGLE `code_interpreter` call.** Do NOT split into multiple calls.
 - Before calling `code_interpreter`, call `artifact_path(filename="presentation.pptx")` to get the S3 bucket and key.
 - After completion, report the `artifact_ref` to the user.
@@ -20,8 +21,6 @@ description: "PowerPoint presentation (.pptx) creation, editing, reading, and ma
 3. Call `code_interpreter` ONCE with a single script that does everything: create the presentation, save it, and upload to S3.
 
 ```python
-!pip install python-pptx
-
 from pptx import Presentation
 import boto3
 
@@ -83,8 +82,6 @@ slide.shapes.add_chart(
 Read .pptx files by downloading from the given S3 path and using tools in `code_interpreter`.
 
 ```python
-!pip install "markitdown[pptx]"
-
 import boto3
 
 s3 = boto3.client('s3')
@@ -307,8 +304,6 @@ Your first render is almost never correct. Approach QA as a bug hunt, not a conf
 ### Content QA
 
 ```python
-!pip install "markitdown[pptx]"
-
 import subprocess
 result = subprocess.run(['python', '-m', 'markitdown', 'output.pptx'], capture_output=True, text=True)
 print(result.stdout)
@@ -359,10 +354,4 @@ This checks for:
 
 ## Dependencies
 
-All dependencies should be installed within code_interpreter:
-```python
-!pip install "markitdown[pptx]"
-!pip install python-pptx
-!pip install Pillow
-!pip install lxml
-```
+`python-pptx`, `markitdown`, `Pillow`, `lxml`, `boto3`, `matplotlib`, `requests` are pre-installed in the Code Interpreter sandbox. Do NOT call `!pip install` — import directly.

--- a/packages/agents/idp-agent/.skills/xlsx/SKILL.md
+++ b/packages/agents/idp-agent/.skills/xlsx/SKILL.md
@@ -8,6 +8,7 @@ description: "Excel spreadsheet (.xlsx) creation, editing, reading, and manipula
 ## Execution Rules
 
 - **ALL code execution MUST use the `code_interpreter` tool.** Do NOT use the `shell` tool.
+- **NEVER call `!pip install`.** `openpyxl`, `pandas`, `boto3`, `numpy`, `Pillow`, `matplotlib`, `lxml` are pre-installed in the AgentCore Code Interpreter sandbox. Import directly. If an import fails, stop and report the error to the user — do not attempt to install anything.
 - **Generate the COMPLETE spreadsheet and upload to S3 in a SINGLE `code_interpreter` call.** Do NOT split into multiple calls.
 - Before calling `code_interpreter`, call `artifact_path(filename="spreadsheet.xlsx")` to get the S3 bucket and key.
 - After completion, report the `artifact_ref` to the user.
@@ -20,8 +21,6 @@ description: "Excel spreadsheet (.xlsx) creation, editing, reading, and manipula
 3. Call `code_interpreter` ONCE with a single script that does everything: create the spreadsheet, save it, and upload to S3.
 
 ```python
-!pip install openpyxl
-
 from openpyxl import Workbook
 import boto3
 
@@ -181,8 +180,6 @@ Read .xlsx files by downloading from the given S3 path and using tools in `code_
 ### Data analysis with pandas
 
 ```python
-!pip install pandas openpyxl
-
 import boto3
 import pandas as pd
 
@@ -230,8 +227,6 @@ Formulas are stored as strings by openpyxl and recalculated automatically when t
 ### Creating new Excel files
 
 ```python
-!pip install openpyxl
-
 from openpyxl import Workbook
 from openpyxl.styles import Font, PatternFill, Alignment
 import boto3
@@ -265,8 +260,6 @@ with open('./output.xlsx', 'rb') as f:
 ### Editing existing Excel files
 
 ```python
-!pip install openpyxl
-
 from openpyxl import load_workbook
 import boto3
 
@@ -328,8 +321,4 @@ with open('./modified.xlsx', 'rb') as f:
 
 ## Dependencies
 
-All dependencies should be installed within code_interpreter:
-```python
-!pip install openpyxl
-!pip install pandas
-```
+`openpyxl`, `pandas`, `boto3`, `numpy`, `Pillow`, `matplotlib` are pre-installed in the Code Interpreter sandbox. Do NOT call `!pip install` — import directly.


### PR DESCRIPTION
  - docx/pptx/xlsx/chart SKILL.md에 `!pip install` 금지 룰 추가
  - 코드 블록에서 `!pip install` 라인 모두 제거
  - 하단 Dependencies 섹션을 "사전 설치됨" 안내로 재작성
  - AgentCore Code Interpreter에 이미 사전 설치된 패키지 사용 명시
  - code_interpreter 분할 호출로 인한 빈 결과 혼동 버그 예방