### PR TITLE
Fix chat history datetime + add artifact refresh

### DIFF
--- a/packages/backend/app/routers/chat.py
+++ b/packages/backend/app/routers/chat.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 
 from fastapi import APIRouter, Header, HTTPException, Query
 from pydantic import BaseModel
@@ -15,8 +16,8 @@ router = APIRouter(prefix="/chat", tags=["chat"])
 class ChatMessage(BaseModel):
     role: str
     content: list[ContentItem]
-    created_at: str
-    updated_at: str
+    created_at: datetime
+    updated_at: datetime
 
 
 class ChatHistoryResponse(BaseModel):

--- a/packages/frontend/src/components/SidePanel.tsx
+++ b/packages/frontend/src/components/SidePanel.tsx
@@ -488,6 +488,7 @@ interface SidePanelProps {
   onArtifactCopy?: (artifact: Artifact) => void;
   onArtifactDownload?: (artifact: Artifact) => void;
   onArtifactDelete?: (artifactId: string) => Promise<void>;
+  onRefreshArtifacts?: () => void;
   onCollapse?: () => void;
   documents?: Document[];
   workflows?: Workflow[];
@@ -507,6 +508,7 @@ export default function SidePanel({
   onArtifactCopy,
   onArtifactDownload,
   onArtifactDelete,
+  onRefreshArtifacts,
   onCollapse,
   documents = [],
   workflows = [],
@@ -1049,6 +1051,15 @@ export default function SidePanel({
             >
               <Search className="h-3.5 w-3.5" />
             </button>
+            {onRefreshArtifacts && (
+              <button
+                onClick={onRefreshArtifacts}
+                className="p-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-white/10 rounded transition-colors flex-shrink-0"
+                title={t('artifacts.refresh', 'Refresh')}
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+              </button>
+            )}
             <div className="flex-1" />
             <span className="text-xs text-slate-400">
               {artSearchQuery

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -471,6 +471,7 @@
     "heroDescription": "Browse and manage all artifacts created during your conversations.\nQuickly copy, download, or organize your generated content.",
     "description": "View and manage generated artifacts",
     "searchPlaceholder": "Search artifacts...",
+    "refresh": "Refresh",
     "noArtifacts": "No artifacts yet",
     "noArtifactsDescription": "Artifacts generated during chat conversations will appear here.",
     "noMatchingArtifacts": "No matching artifacts",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -471,6 +471,7 @@
     "heroDescription": "会話中に作成されたすべてのアーティファクトを閲覧・管理できます。\n生成されたコンテンツをすばやくコピー、ダウンロード、整理できます。",
     "description": "生成されたアーティファクトの表示と管理",
     "searchPlaceholder": "アーティファクトを検索...",
+    "refresh": "更新",
     "noArtifacts": "アーティファクトがありません",
     "noArtifactsDescription": "チャット会話中に生成されたアーティファクトがここに表示されます。",
     "noMatchingArtifacts": "一致するアーティファクトがありません",

--- a/packages/frontend/src/i18n/locales/ko.json
+++ b/packages/frontend/src/i18n/locales/ko.json
@@ -471,6 +471,7 @@
     "heroDescription": "대화 중에 생성된 모든 아티팩트를 탐색하고 관리하세요.\n생성된 콘텐츠를 빠르게 복사, 다운로드하거나 정리할 수 있습니다.",
     "description": "생성된 아티팩트 보기 및 관리",
     "searchPlaceholder": "아티팩트 검색...",
+    "refresh": "새로고침",
     "noArtifacts": "아티팩트가 없습니다",
     "noArtifactsDescription": "채팅 대화 중에 생성된 아티팩트가 여기에 표시됩니다.",
     "noMatchingArtifacts": "일치하는 아티팩트가 없습니다",

--- a/packages/frontend/src/routes/projects/$projectId.tsx
+++ b/packages/frontend/src/routes/projects/$projectId.tsx
@@ -396,6 +396,7 @@ function ProjectDetailPage() {
                     onArtifactSelect={artifactsHook.handleArtifactSelect}
                     onArtifactDownload={artifactsHook.handleArtifactDownload}
                     onArtifactDelete={artifactsHook.handleArtifactDelete}
+                    onRefreshArtifacts={artifactsHook.loadArtifacts}
                     onCollapse={() => panelLayout.setSidePanelCollapsed(true)}
                     documents={documentsHook.documents}
                     workflows={documentsHook.workflows}


### PR DESCRIPTION
  - ChatMessage 모델의 created_at/updated_at 타입을 str → datetime으로 변경 (DuckDB의 자동 timestamp 파싱과 호환)
  - SidePanel 아티팩트 헤더에 새로고침 버튼 추가 (RefreshCw 아이콘)
  - onRefreshArtifacts prop 추가, useArtifacts.loadArtifacts 연결