### PR TITLE
Add SyntaxCheckHook to validate code before exec

### DIFF
--- a/packages/agents/idp-agent/agents/idp_agent.py
+++ b/packages/agents/idp-agent/agents/idp_agent.py
@@ -18,6 +18,7 @@ from prompts import build_system_prompt
 from tools.artifact import create_artifact_path_tool
 
 from .image_artifact_saver_hook import ImageArtifactSaverHook
+from .syntax_check_hook import SyntaxCheckHook
 from .tool_parameter_enforcer_hook import ToolParameterEnforcerHook
 
 
@@ -135,6 +136,7 @@ def get_agent(
     hooks: list[HookProvider] = [
         ToolParameterEnforcerHook(user_id=user_id, project_id=project_id),
         ImageArtifactSaverHook(user_id=user_id, project_id=project_id),
+        SyntaxCheckHook(),
     ]
 
     skills_plugin = AgentSkills(skills="./.skills/")

--- a/packages/agents/idp-agent/agents/syntax_check_hook.py
+++ b/packages/agents/idp-agent/agents/syntax_check_hook.py
@@ -1,0 +1,53 @@
+import ast
+import logging
+
+from strands.hooks.events import BeforeToolCallEvent
+from strands.hooks.registry import HookProvider, HookRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class SyntaxCheckHook(HookProvider):
+    """Pre-flight Python syntax check for code_interpreter calls.
+
+    Compiles the generated Python code with `compile()` before dispatching
+    to the AgentCore sandbox. On SyntaxError, cancels the tool call and
+    returns a clean error message to the model so it can fix and retry
+    without paying sandbox cold-start latency.
+    """
+
+    def register_hooks(self, registry: HookRegistry, **kwargs) -> None:
+        registry.add_callback(BeforeToolCallEvent, self._check)
+
+    def _check(self, event: BeforeToolCallEvent) -> None:
+        if event.selected_tool is None:
+            return
+        if event.selected_tool.tool_name != "code_interpreter":
+            return
+
+        action = event.tool_use.get("input", {}).get("code_interpreter_input", {}).get("action", {})
+        if action.get("type") != "executeCode":
+            return
+        if action.get("language") != "python":
+            return
+
+        code = action.get("code", "")
+        if not code:
+            return
+
+        try:
+            compile(code, "<agent-generated>", "exec", flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+        except SyntaxError as e:
+            line_text = (e.text or "").rstrip()
+            message = (
+                f"SyntaxError: {e.msg} (line {e.lineno}, col {e.offset})\n"
+                f"  {line_text}\n"
+                "Pre-execution syntax check failed. Fix the syntax error and retry. "
+                "Common causes: non-ASCII characters used as bare tokens (em-dash, smart quotes), "
+                "unclosed brackets/strings, indentation mistakes."
+            )
+            logger.warning(
+                "SyntaxCheckHook: cancelled code_interpreter call due to SyntaxError at line %s",
+                e.lineno,
+            )
+            event.cancel_tool = message


### PR DESCRIPTION
  - code_interpreter 호출 직전 Python compile()로 사전 문법 검사하는 SyntaxCheckHook 추가
  - BeforeToolCallEvent에서 SyntaxError 감지 시 cancel_tool로 short-circuit
  - idp_agent.py hooks 리스트에 SyntaxCheckHook 등록