### PR TITLE
Increase Lambda memory and improve agent stability

### DIFF
--- a/packages/agents/idp-agent/.skills/pptx/SKILL.md
+++ b/packages/agents/idp-agent/.skills/pptx/SKILL.md
@@ -9,41 +9,144 @@ description: "PowerPoint presentation (.pptx) creation, editing, reading, and ma
 
 - **ALL code execution MUST use the `code_interpreter` tool.** Do NOT use the `shell` tool.
 - **NEVER call `!pip install`.** `python-pptx`, `boto3`, `Pillow`, `lxml`, `matplotlib`, `numpy`, `requests`, `markitdown` are pre-installed in the AgentCore Code Interpreter sandbox. Import directly. If an import fails, stop and report the error to the user — do not attempt to install anything.
-- **Generate the COMPLETE presentation and upload to S3 in a SINGLE `code_interpreter` call.** Do NOT split into multiple calls.
+- **Build the presentation INCREMENTALLY across multiple small `code_interpreter` calls, one or two slides per call.** Do NOT cram the entire deck into a single 30+ KB script. See the Incremental Workflow below.
+- **EVERY `code_interpreter` call MUST end with a `print(...)` that reports progress.** Empty stdout is interpreted by the runtime as a failure. Always print at least one line describing what was accomplished.
 - Before calling `code_interpreter`, call `artifact_path(filename="presentation.pptx")` to get the S3 bucket and key.
-- After completion, report the `artifact_ref` to the user.
+- After the final upload, report the `artifact_ref` to the user.
 - **If `code_interpreter` fails with an error, do NOT retry automatically.** Report the error to the user and ask for clarification or guidance. Do not make multiple retry attempts without user input.
 
-### Workflow
+## Incremental Workflow
 
-1. Call `artifact_path(filename="presentation.pptx")` — returns `{ s3_uri, bucket, key, artifact_ref }`
-2. **Copy the actual `s3_uri` string value** from the artifact_path result and **hardcode it as a string literal** in your code_interpreter script. Do NOT use variable references — the code_interpreter runs in an isolated sandbox and cannot access the agent's tool results.
-3. Call `code_interpreter` ONCE with a single script that does everything: create the presentation, save it, and upload to S3.
+The AgentCore Code Interpreter preserves session state between calls — files written to `/tmp` in one `code_interpreter` invocation remain available in the next call of the same session. Use this to build the deck one slide at a time instead of generating all slides in a single monolithic script.
+
+**Benefits:**
+- Each call is small (~1–3 KB of code) and generates in ~15–25 seconds instead of 4+ minutes.
+- Failures affect only one slide — previous slides stay saved in `/tmp/deck.pptx`.
+- Users see real-time progress: "slide 3/12 added" appears in the UI after each call.
+
+### Call sequence (typical 10-slide deck)
+
+1. `artifact_path(filename="presentation.pptx")` — get S3 URI (ONCE)
+2. **Call #1** — Create empty deck, set slide size/theme, save to `/tmp/deck.pptx`
+3. **Call #2** — Load deck, add slide 1 (title slide), save
+4. **Call #3** — Load deck, add slide 2 (content), save
+5. ... one call per slide (or two slides per call if small) ...
+6. **Call #N+1** — Load deck, upload `/tmp/deck.pptx` to S3
+7. Report `artifact_ref`
+
+### Call #1 — Create empty deck
 
 ```python
 from pptx import Presentation
+from pptx.util import Inches
+
+pres = Presentation()
+pres.slide_width = Inches(13.333)   # 16:9
+pres.slide_height = Inches(7.5)
+pres.save('/tmp/deck.pptx')
+print(f"Created blank deck: 16:9, 0 slides. Target total: 10 slides.")
+```
+
+### Call #2 — Title slide
+
+```python
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+
+pres = Presentation('/tmp/deck.pptx')   # load existing
+slide = pres.slides.add_slide(pres.slide_layouts[6])   # blank layout
+
+# Title
+title_box = slide.shapes.add_textbox(Inches(0.5), Inches(2.8), Inches(12.3), Inches(1.5))
+tf = title_box.text_frame
+p = tf.paragraphs[0]
+p.text = "<presentation title>"
+p.alignment = PP_ALIGN.CENTER
+p.runs[0].font.size = Pt(44)
+p.runs[0].font.bold = True
+p.runs[0].font.color.rgb = RGBColor(0x1F, 0x39, 0x64)
+
+# Subtitle
+sub_box = slide.shapes.add_textbox(Inches(0.5), Inches(4.5), Inches(12.3), Inches(0.8))
+sub_p = sub_box.text_frame.paragraphs[0]
+sub_p.text = "<subtitle / author / date>"
+sub_p.alignment = PP_ALIGN.CENTER
+sub_p.runs[0].font.size = Pt(20)
+sub_p.runs[0].font.color.rgb = RGBColor(0x66, 0x66, 0x66)
+
+pres.save('/tmp/deck.pptx')
+print(f"Slide 1/{TOTAL} (title) added. Deck now has {len(pres.slides)} slides.")
+```
+
+### Call #3…N — Each content slide follows the same load → add → save → print pattern
+
+```python
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.dml.color import RGBColor
+
+pres = Presentation('/tmp/deck.pptx')
+slide = pres.slides.add_slide(pres.slide_layouts[6])
+
+# Slide title
+title = slide.shapes.add_textbox(Inches(0.5), Inches(0.3), Inches(12.3), Inches(0.8))
+t_p = title.text_frame.paragraphs[0]
+t_p.text = "<slide title>"
+t_p.runs[0].font.size = Pt(28)
+t_p.runs[0].font.bold = True
+t_p.runs[0].font.color.rgb = RGBColor(0x1F, 0x39, 0x64)
+
+# Body content (bullet list example — replace bullets with actual content)
+body = slide.shapes.add_textbox(Inches(0.5), Inches(1.5), Inches(12.3), Inches(5.5))
+body_tf = body.text_frame
+body_tf.word_wrap = True
+bullets = ["<bullet 1>", "<bullet 2>", "<bullet 3>"]
+for i, bullet in enumerate(bullets):
+    p = body_tf.add_paragraph() if i > 0 else body_tf.paragraphs[0]
+    p.text = f"• {bullet}"
+    p.runs[0].font.size = Pt(20)
+
+pres.save('/tmp/deck.pptx')
+print(f"Slide {len(pres.slides)}/{TOTAL} added.")
+```
+
+### Call #N+1 — Upload
+
+```python
 import boto3
 
-# IMPORTANT: Replace with the ACTUAL s3_uri value returned by artifact_path
-S3_URI = "s3://my-bucket/user123/proj456/artifacts/art_abc123/presentation.pptx"  # ← paste the actual s3_uri here
-
-# Parse S3 URI into bucket and key
+S3_URI = "s3://idp-v2-agent-storage-008165007574/user/proj/artifacts/art_xxx/deck.pptx"   # paste from artifact_path
 BUCKET, KEY = S3_URI.replace("s3://", "").split("/", 1)
 
-# Build entire presentation
-pres = Presentation()
-# ... all presentation content ...
-pres.save('./output.pptx')
-
-# Upload to S3
 s3 = boto3.client('s3')
-with open('./output.pptx', 'rb') as f:
+with open('/tmp/deck.pptx', 'rb') as f:
     s3.upload_fileobj(
         f, BUCKET, KEY,
-        ExtraArgs={'ContentType': 'application/vnd.openxmlformats-officedocument.presentationml.presentation'}
+        ExtraArgs={
+            'ContentType': 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+        }
     )
+
+# Verify
+from pptx import Presentation
+final = Presentation('/tmp/deck.pptx')
+print(f"✅ Uploaded {len(final.slides)} slides to s3://{BUCKET}/{KEY}")
 ```
-4. Report the `artifact_ref` to the user
+
+Then report the `artifact_ref` to the user.
+
+### Important rules for the incremental workflow
+
+- **Always load the deck from `/tmp/deck.pptx` at the start of each call** — do NOT create a new `Presentation()` except in call #1.
+- **Always save back to `/tmp/deck.pptx` at the end of each call** (except the upload call).
+- **Each call MUST `print()` at least once** — the runtime treats empty stdout as failure.
+- **Use the same filename `/tmp/deck.pptx` throughout** — do not rename between calls.
+- **Hardcode the S3 URI string** in the upload call (sandbox cannot access agent variables).
+- **Do not split a single slide across multiple calls** — always complete one slide per call at minimum.
+- **For 2+ slides per call**, group logically related slides (e.g., two comparison slides together). Keep total code under ~5 KB per call.
+- **If a call errors out**, the previous successful saves are still on disk. You can resume from the failed slide.
 
 ---
 

--- a/packages/agents/idp-agent/agents/syntax_check_hook.py
+++ b/packages/agents/idp-agent/agents/syntax_check_hook.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import logging
 
 from strands.hooks.events import BeforeToolCallEvent
@@ -14,40 +15,78 @@ class SyntaxCheckHook(HookProvider):
     to the AgentCore sandbox. On SyntaxError, cancels the tool call and
     returns a clean error message to the model so it can fix and retry
     without paying sandbox cold-start latency.
+
+    The hook MUST NOT raise exceptions out of the callback — any failure
+    here would propagate up through the Strands event loop and kill the
+    entire agent stream. On any unexpected error, silently skip the check
+    and let the tool dispatch proceed as normal.
     """
 
     def register_hooks(self, registry: HookRegistry, **kwargs) -> None:
         registry.add_callback(BeforeToolCallEvent, self._check)
 
     def _check(self, event: BeforeToolCallEvent) -> None:
-        if event.selected_tool is None:
-            return
-        if event.selected_tool.tool_name != "code_interpreter":
-            return
-
-        action = event.tool_use.get("input", {}).get("code_interpreter_input", {}).get("action", {})
-        if action.get("type") != "executeCode":
-            return
-        if action.get("language") != "python":
-            return
-
-        code = action.get("code", "")
-        if not code:
-            return
-
         try:
-            compile(code, "<agent-generated>", "exec", flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
-        except SyntaxError as e:
-            line_text = (e.text or "").rstrip()
-            message = (
-                f"SyntaxError: {e.msg} (line {e.lineno}, col {e.offset})\n"
-                f"  {line_text}\n"
-                "Pre-execution syntax check failed. Fix the syntax error and retry. "
-                "Common causes: non-ASCII characters used as bare tokens (em-dash, smart quotes), "
-                "unclosed brackets/strings, indentation mistakes."
-            )
+            if event.selected_tool is None:
+                return
+            if event.selected_tool.tool_name != "code_interpreter":
+                return
+
+            input_data = event.tool_use.get("input", {})
+            if not isinstance(input_data, dict):
+                return
+
+            ci_input = input_data.get("code_interpreter_input", {})
+            # Model sometimes wraps the whole structured input as a JSON string
+            # instead of a dict — defensively parse it.
+            if isinstance(ci_input, str):
+                try:
+                    ci_input = json.loads(ci_input)
+                except (json.JSONDecodeError, ValueError):
+                    return
+            if not isinstance(ci_input, dict):
+                return
+
+            action = ci_input.get("action", {})
+            if isinstance(action, str):
+                try:
+                    action = json.loads(action)
+                except (json.JSONDecodeError, ValueError):
+                    return
+            if not isinstance(action, dict):
+                return
+
+            if action.get("type") != "executeCode":
+                return
+            if action.get("language") != "python":
+                return
+
+            code = action.get("code", "")
+            if not isinstance(code, str) or not code:
+                return
+
+            try:
+                compile(code, "<agent-generated>", "exec", flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+            except SyntaxError as e:
+                line_text = (e.text or "").rstrip()
+                message = (
+                    f"SyntaxError: {e.msg} (line {e.lineno}, col {e.offset})\n"
+                    f"  {line_text}\n"
+                    "Pre-execution syntax check failed. Fix the syntax error and retry. "
+                    "Common causes: non-ASCII characters used as bare tokens (em-dash, smart quotes), "
+                    "unclosed brackets/strings, indentation mistakes."
+                )
+                logger.warning(
+                    "SyntaxCheckHook: cancelled code_interpreter call due to SyntaxError at line %s",
+                    e.lineno,
+                )
+                event.cancel_tool = message
+
+        except Exception as exc:
+            # Hook failures MUST NOT break the agent event loop.
+            # Log and let the tool dispatch proceed normally.
             logger.warning(
-                "SyntaxCheckHook: cancelled code_interpreter call due to SyntaxError at line %s",
-                e.lineno,
+                "SyntaxCheckHook: unexpected error, skipping syntax check (%s: %s)",
+                type(exc).__name__,
+                exc,
             )
-            event.cancel_tool = message

--- a/packages/agents/idp-agent/main.py
+++ b/packages/agents/idp-agent/main.py
@@ -48,17 +48,27 @@ def filter_stream_event(event: dict) -> list[dict]:
     if "data" in event:
         return [{"type": "text", "content": event["data"]}]
 
+    # Tool use streaming — Strands emits ToolUseStreamEvent per Bedrock
+    # contentBlockDelta. For large tool_use payloads (e.g. 35KB code) this
+    # fires 1000s of times. We yield a lightweight event per delta to keep
+    # the HTTP stream alive (prevents intermediate proxy idle timeouts
+    # during long generation) without blasting the growing input string
+    # across the wire on every delta.
+    #
+    # The frontend dedupes tool_use events by tool_use_id, so only one UI
+    # block is rendered. The final tool_use result flows to the client via
+    # the subsequent tool_result message — users don't need the partial
+    # input during generation.
     if "current_tool_use" in event:
         tool_use = event["current_tool_use"]
-        if tool_use.get("name"):
-            result = {
-                "type": "tool_use",
-                "name": tool_use["name"],
-                "tool_use_id": tool_use.get("toolUseId", ""),
-            }
-            if tool_use.get("input"):
-                result["input"] = tool_use["input"]
-            return [result]
+        if isinstance(tool_use, dict) and tool_use.get("name"):
+            return [
+                {
+                    "type": "tool_use",
+                    "name": tool_use["name"],
+                    "tool_use_id": tool_use.get("toolUseId", ""),
+                }
+            ]
 
     if "message" in event and event["message"].get("role") == "user":
         results = []

--- a/packages/agents/webcrawler-agent/agents/crawler.py
+++ b/packages/agents/webcrawler-agent/agents/crawler.py
@@ -4,9 +4,10 @@ import asyncio
 import json
 import logging
 import os
+import queue as _queue
 import threading
 from datetime import datetime, timezone
-from typing import Callable
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 import boto3
@@ -19,6 +20,11 @@ from agents.d2snap import D2Snap, estimate_tokens
 logger = logging.getLogger(__name__)
 
 config = get_config()
+
+# Per-browser-action timeout (seconds). If a single navigate/get_html/click
+# exceeds this window, the wrapper returns an error instead of blocking so
+# the agent can skip the URL and continue with a different one.
+BROWSER_ACTION_TIMEOUT_SECS = int(os.environ.get("BROWSER_ACTION_TIMEOUT_SECS", "90"))
 
 # Initialize clients
 s3_client = boto3.client("s3", region_name=config.aws_region)
@@ -53,6 +59,27 @@ IMPORTANT:
   - Single article/page with no meaningful sub-links -> just extract that page
 - Maximum ~20 pages to avoid excessive crawling
 - Each saved page should contain substantive content, not just navigation
+
+<error_handling>
+Each browser action has a per-call timeout (default 90 seconds). If an
+action fails or times out, you receive a JSON object with an `error` field
+and possibly `timeout: true`. When that happens:
+
+1. **SKIP the failing URL immediately** — do NOT retry the same URL.
+   Retrying a hung URL will just hang again.
+2. **Continue with a different URL** from the remaining candidates.
+3. **If you run out of candidates**, close the browser and finish with
+   whatever pages you have successfully saved so far.
+4. **Partial results are valuable** — a crawl that saves 5 out of 10
+   planned pages is a success, not a failure. Always save what you have
+   and close cleanly.
+
+Common failure modes to skip-and-continue on:
+- Site is bot-blocked or returns a challenge page (CAPTCHA, Cloudflare)
+- Page never finishes loading (slow server, infinite redirect)
+- URL returns 404/403/5xx
+- Content is empty or tiny after compression (JS-only SPA we cannot render)
+</error_handling>
 </workflow>
 
 <content_format>
@@ -194,6 +221,129 @@ def get_current_time() -> str:
     return "\n".join(result)
 
 
+def _invoke_browser_with_timeout(
+    browser_tool: AgentCoreBrowser,
+    browser_input: dict,
+    timeout_secs: int = BROWSER_ACTION_TIMEOUT_SECS,
+) -> tuple[str, Any]:
+    """Call `browser_tool.browser(browser_input=...)` with a per-action timeout.
+
+    Returns a tuple `(status, value)`:
+      - `("ok", result)` on success
+      - `("timeout", error_message)` if the call exceeds `timeout_secs`
+      - `("error", exception_instance)` if the call raises
+
+    The underlying browser call runs in a daemon thread. On timeout the
+    background thread is NOT killed (Playwright does not support cancellation
+    cleanly); it will eventually complete in the background. The agent,
+    however, is freed to move on to a different URL.
+    """
+    action_type = "unknown"
+    action_target = ""
+    try:
+        if isinstance(browser_input, dict):
+            action = browser_input.get("action", {}) or {}
+            if isinstance(action, dict):
+                action_type = action.get("type", "unknown")
+                action_target = action.get("url") or action.get("selector") or ""
+    except Exception:
+        pass
+
+    result_q: _queue.Queue = _queue.Queue()
+
+    def _invoke() -> None:
+        try:
+            result = browser_tool.browser(browser_input=browser_input)
+            result_q.put(("ok", result))
+        except Exception as exc:
+            result_q.put(("error", exc))
+
+    worker = threading.Thread(target=_invoke, daemon=True)
+    worker.start()
+
+    try:
+        return result_q.get(timeout=timeout_secs)
+    except _queue.Empty:
+        msg = (
+            f"Browser action '{action_type}' exceeded {timeout_secs}s timeout"
+            + (f" for {action_target}" if action_target else "")
+        )
+        logger.warning(f"[BROWSER_TIMEOUT] {msg}")
+        return ("timeout", msg)
+
+
+def create_safe_browser_tool(
+    browser_tool: AgentCoreBrowser,
+    timeout_secs: int = BROWSER_ACTION_TIMEOUT_SECS,
+) -> Callable:
+    """Create a timeout-guarded wrapper around `browser_tool.browser`.
+
+    When a single action (e.g. navigate to an unresponsive URL) hangs for
+    longer than `timeout_secs`, this wrapper returns a structured JSON error
+    to the agent instead of blocking the entire run. The agent is expected
+    to skip the failing URL and continue with a different one (see system
+    prompt).
+    """
+
+    @tool
+    def browser(browser_input: dict) -> str:
+        """Interact with the AgentCore browser. Each action has a per-call
+        timeout so unresponsive URLs don't stall the whole crawl.
+
+        `browser_input` format examples:
+          - Navigate:   {"action": {"type": "navigate", "session_name": "s1", "url": "https://..."}}
+          - Get HTML:   {"action": {"type": "get_html", "session_name": "s1"}}
+          - Screenshot: {"action": {"type": "screenshot", "session_name": "s1"}}
+          - Click:      {"action": {"type": "click", "session_name": "s1", "selector": "..."}}
+          - Type:       {"action": {"type": "type", "session_name": "s1", "selector": "...", "text": "..."}}
+          - Close:      {"action": {"type": "close_browser"}}
+
+        If the action times out or errors, you receive a JSON object
+        containing `error`, `timeout` (bool), and `action_type` fields. When
+        that happens, SKIP the current URL and move on to a different URL.
+        Do NOT retry the same URL — it will just hang again.
+        """
+        action_type = "unknown"
+        action_target = ""
+        try:
+            if isinstance(browser_input, dict):
+                action = browser_input.get("action", {}) or {}
+                if isinstance(action, dict):
+                    action_type = action.get("type", "unknown")
+                    action_target = action.get("url") or action.get("selector") or ""
+        except Exception:
+            pass
+
+        status, value = _invoke_browser_with_timeout(browser_tool, browser_input, timeout_secs)
+
+        if status == "ok":
+            return value
+        if status == "timeout":
+            return json.dumps(
+                {
+                    "error": str(value),
+                    "timeout": True,
+                    "action_type": action_type,
+                    "target": action_target,
+                    "hint": "Skip this URL and continue with a different one. Do not retry.",
+                },
+                ensure_ascii=False,
+            )
+        # status == "error"
+        logger.warning(f"[BROWSER_ERR] action={action_type} target={action_target} error={value}")
+        return json.dumps(
+            {
+                "error": str(value),
+                "action_type": action_type,
+                "target": action_target,
+                "hint": "This action failed. Try a different URL or a different approach.",
+            },
+            ensure_ascii=False,
+        )
+
+    return browser
+
+
 def create_get_compressed_html_tool(browser_tool: AgentCoreBrowser) -> Callable:
     """Create a get_compressed_html tool for efficient HTML analysis."""
 
@@ -216,14 +366,22 @@ def create_get_compressed_html_tool(browser_tool: AgentCoreBrowser) -> Callable:
         import time
 
         def _extract_html() -> str:
-            html_result = browser_tool.browser(
-                browser_input={
+            status, result = _invoke_browser_with_timeout(
+                browser_tool,
+                {
                     "action": {
                         "type": "get_html",
                         "session_name": session_name,
                     }
-                }
+                },
             )
+            if status != "ok":
+                # Return empty string so caller falls through to the
+                # "HTML too small" retry / warning path; never raise here
+                # because that would abort the agent step.
+                logger.warning(f"_extract_html {status}: {result}")
+                return ""
+            html_result = result
             raw = ""
             if isinstance(html_result, dict):
                 content = html_result.get("content", [])
@@ -431,12 +589,18 @@ async def crawl_and_process(
         # Create custom tools with context
         save_page_tool, page_state = create_save_page_tool(file_uri)
         get_compressed_html_tool = create_get_compressed_html_tool(browser_tool)
+        # Wrap the raw browser tool with a per-action timeout so a single
+        # unresponsive URL (e.g. bot-blocked article page) cannot hang the
+        # whole crawl for the full AgentCore idle window.
+        safe_browser_tool = create_safe_browser_tool(
+            browser_tool, timeout_secs=BROWSER_ACTION_TIMEOUT_SECS
+        )
 
         # Create agent with browser tool and custom tools
         logger.info(f"Creating agent with model={config.bedrock_model_id}")
         agent = Agent(
             model=config.bedrock_model_id,
-            tools=[browser_tool.browser, save_page_tool, get_compressed_html_tool, get_current_time],
+            tools=[safe_browser_tool, save_page_tool, get_compressed_html_tool, get_current_time],
             system_prompt=system_prompt,
         )
         logger.info("Agent created successfully")
@@ -467,7 +631,10 @@ IMPORTANT:
         loop = asyncio.get_running_loop()
         future = loop.create_future()
 
-        AGENT_TIMEOUT_SECS = int(os.environ.get("AGENT_TIMEOUT_SECS", "1800"))
+        # Keep agent-level timeout BELOW AgentCore idle session timeout (15 min)
+        # so the agent surfaces a clean TimeoutError via update_preprocess_status
+        # BEFORE AgentCore tears down the container silently.
+        AGENT_TIMEOUT_SECS = int(os.environ.get("AGENT_TIMEOUT_SECS", "780"))
 
         def _run_agent():
             try:

--- a/packages/infra/src/stacks/workflow-stack.ts
+++ b/packages/infra/src/stacks/workflow-stack.ts
@@ -720,7 +720,7 @@ export class WorkflowStack extends Stack {
         functionName: 'idp-v2-page-description-generator',
         handler: 'index.handler',
         timeout: Duration.minutes(5),
-        memorySize: 512,
+        memorySize: 1024,
         code: lambda.Code.fromAsset(
           path.join(
             __dirname,
@@ -741,7 +741,7 @@ export class WorkflowStack extends Stack {
       functionName: 'idp-v2-entity-extractor',
       handler: 'index.handler',
       timeout: Duration.minutes(5),
-      memorySize: 512,
+      memorySize: 1024,
       code: lambda.Code.fromAsset(
         path.join(__dirname, '../functions/step-functions/entity-extractor'),
       ),
@@ -1386,8 +1386,15 @@ export class WorkflowStack extends Stack {
     // Route based on ocr_backend after orchestrator
     const ocrBackendChoice = new sfn.Choice(this, 'OcrBackendChoice', {
       comment:
-        'Route OCR processing based on backend: "lambda" runs parallel chunk Map then merge; "sagemaker" enters async polling loop',
+        'Route OCR processing: SKIPPED short-circuits to done; "lambda" runs parallel chunk Map then merge; "sagemaker" enters async polling loop',
     })
+      .when(
+        sfn.Condition.stringEquals('$.ocr_status', 'SKIPPED'),
+        new sfn.Pass(this, 'OcrSkippedDone', {
+          comment:
+            'OCR skipped for unsupported file type (e.g. pptx/docx handled by format parser)',
+        }),
+      )
       .when(
         sfn.Condition.stringEquals('$.ocr_backend', 'lambda'),
         ocrChunkMap.next(ocrChunkMergerTask),


### PR DESCRIPTION
  - workflow-stack: page-description-generator/entity-extractor 메모리 512→1024MB로 증가 (OOM kill 방지)
  - workflow-stack: OcrBackendChoice에 ocr_status=SKIPPED 분기 추가 (pptx/docx short-circuit)
  - crawler.py: 브라우저 액션별 90초 타임아웃 + 실패 URL skip-and-continue 로직 추가
  - crawler.py: agent 전체 timeout 1800s→780s로 단축 (AgentCore 15분 idle 이전에 깔끔 종료)
  - syntax_check_hook.py: hook 전체를 try/except로 감싸 agent event loop 보호, JSON string input 방어 처리
  - main.py: 큰 tool_use payload streaming 시 input 필드 제외하고 keep-alive만 전송
  - pptx/SKILL.md: PPTX 생성을 단일 스크립트→슬라이드별 점진 생성 워크플로우로 전환
