### PR TITLE
Pin pnpm to v10 for CodeBuild compatibility

### DIFF
--- a/deploy-codebuild.yml
+++ b/deploy-codebuild.yml
@@ -105,7 +105,7 @@ Resources:
                 nodejs: 22
                 python: 3.13
               commands:
-                - npm install -g pnpm aws-cdk@latest
+                - npm install -g pnpm@10 aws-cdk@latest
 
             pre_build:
               commands:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@idp-v2/source",
   "version": "0.2.5",
   "license": "SEE LICENSE IN LICENSE",
+  "packageManager": "pnpm@10.29.3",
   "scripts": {
     "build:all": "nx run-many --target build --all",
     "affected:all": "nx affected --target build"


### PR DESCRIPTION
  - deploy-codebuild.yml: CodeBuild buildspec의 pnpm 설치를 `pnpm@10`으로 고정 (기존 `latest`가 pnpm 11을 받아 lockfile mismatch 발생)
  - package.json: `packageManager: "pnpm@10.29.3"` 필드 추가로 로컬/CI 버전 일관성 보장
