### PR TITLE
Add streaming Ask AI chat page to docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,8 +25,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -30,8 +30,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/docs/ask.config.mjs
+++ b/docs/ask.config.mjs
@@ -1,0 +1,12 @@
+// Configuration for the "Ask AI" chat page.
+// Edit this file to change the endpoint or turn the feature on/off.
+// Imported by both astro.config.mjs (sidebar + dev proxy) and AskChat.astro.
+
+/** @type {{ enabled: boolean, endpoint: string }} */
+export const askConfig = {
+  // Set to false to hide the Ask AI page entirely (sidebar link + the chat UI).
+  enabled: true,
+
+  // Streaming SSE endpoint. Must emit `data: {"delta":"..."}` and `data: [DONE]`.
+  endpoint: 'https://d9sagqklx4lwu.cloudfront.net',
+};

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import mermaid from 'astro-mermaid';
 import { stripMdLinksIntegration } from './remark-strip-md-links.mjs';
+import { askConfig } from './ask.config.mjs';
 import { readFileSync } from 'node:fs';
 
 const rootPkg = JSON.parse(
@@ -19,6 +20,7 @@ export default defineConfig({
       title: 'AWS IDP Pipeline',
       components: {
         SiteTitle: './src/components/SiteTitle.astro',
+        PageSidebar: './src/components/AskPageSidebar.astro',
       },
       social: [
         {
@@ -48,6 +50,18 @@ export default defineConfig({
           },
           link: '/',
         },
+        ...(askConfig.enabled
+          ? [
+              {
+                label: 'Ask AI',
+                translations: {
+                  ko: 'AI에게 물어보기',
+                  ja: 'AIに質問',
+                },
+                link: '/ask',
+              },
+            ]
+          : []),
         {
           label: 'Features',
           translations: {
@@ -219,6 +233,17 @@ export default defineConfig({
   vite: {
     ssr: {
       noExternal: ['nanoid'],
+    },
+    // Dev-only proxy so the Ask AI chat can reach the streaming endpoint
+    // without hitting CORS. In production the endpoint is called directly.
+    server: {
+      proxy: {
+        '/ask-api': {
+          target: askConfig.endpoint,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ask-api/, ''),
+        },
+      },
     },
   },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,8 @@
     "@astrojs/starlight": "^0.37.6",
     "astro": "^5.18.1",
     "astro-mermaid": "^1.3.1",
+    "highlight.js": "^11.11.1",
+    "marked": "^18.0.5",
     "mermaid": "^11.12.3",
     "sharp": "^0.34.2",
     "unist-util-visit": "^5.1.0"

--- a/docs/src/components/AskChat.astro
+++ b/docs/src/components/AskChat.astro
@@ -1,0 +1,748 @@
+---
+// Streaming chat UI for asking questions about the repository.
+// Talks to an SSE-style endpoint that emits `data: {"delta":"..."}` lines,
+// `[TOOL] <name>` markers for tool execution, and `data: [DONE]` to finish.
+// In dev, requests go through the Vite proxy at `/ask-api` (see astro.config.mjs)
+// to avoid CORS; in production the full endpoint URL is used directly.
+//
+// Endpoint and on/off are configured in ../../ask.config.mjs. The `endpoint`
+// prop still overrides the config value when explicitly passed.
+import { askConfig } from '../../ask.config.mjs';
+
+interface Props {
+  endpoint?: string;
+}
+
+const { endpoint = askConfig.endpoint } = Astro.props;
+const { enabled } = askConfig;
+
+const locale = Astro.locals.starlightRoute?.locale ?? 'en';
+
+const ui = {
+  en: {
+    disabled: 'The Ask AI feature is currently disabled.',
+    title: 'Ask about this repository',
+    sub: 'Answers stream in real time.',
+    placeholder: 'Ask a question...',
+    suggestions: [
+      'How is OCR implemented?',
+      'Explain the document analysis workflow',
+      'What is the DynamoDB schema?',
+    ],
+  },
+  ko: {
+    disabled: 'AI에게 물어보기 기능이 현재 비활성화되어 있습니다.',
+    title: '이 저장소에 대해 물어보세요',
+    sub: '답변은 실시간으로 스트리밍됩니다.',
+    placeholder: '질문을 입력하세요...',
+    suggestions: [
+      'OCR은 어떻게 구현되어 있나요?',
+      '문서 분석 워크플로우를 설명해 주세요',
+      'DynamoDB 스키마는 어떻게 되나요?',
+    ],
+  },
+  ja: {
+    disabled: 'AIに質問する機能は現在無効になっています。',
+    title: 'このリポジトリについて質問する',
+    sub: '回答はリアルタイムでストリーミングされます。',
+    placeholder: '質問を入力してください...',
+    suggestions: [
+      'OCR はどのように実装されていますか？',
+      'ドキュメント分析ワークフローを説明してください',
+      'DynamoDB のスキーマはどうなっていますか？',
+    ],
+  },
+};
+
+const u = ui[locale] ?? ui.en;
+---
+
+{!enabled && <p class="ask-disabled not-content">{u.disabled}</p>}
+
+{enabled && (
+<div class="ask-chat not-content" data-endpoint={endpoint}>
+  <div class="ask-thread" aria-live="polite">
+    <div class="ask-empty">
+      <p class="ask-empty-title">{u.title}</p>
+      <p class="ask-empty-sub">{u.sub}</p>
+      <div class="ask-suggestions">
+        {u.suggestions.map((s) => (
+          <button type="button" class="ask-chip-suggest">{s}</button>
+        ))}
+      </div>
+    </div>
+  </div>
+
+  <form class="ask-form" autocomplete="off">
+    <span class="ask-prompt-mark">&gt;</span>
+    <textarea
+      class="ask-input"
+      name="prompt"
+      placeholder={u.placeholder}
+      aria-label="Question"
+      rows="1"></textarea>
+    <button type="submit" class="ask-send" aria-label="Send">
+      <svg class="ask-send-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="5" y1="12" x2="19" y2="12"></line>
+        <polyline points="12 5 19 12 12 19"></polyline>
+      </svg>
+      <span class="ask-send-stop"></span>
+    </button>
+  </form>
+</div>
+)}
+
+<script>
+  import { marked } from 'marked';
+  import hljs from 'highlight.js';
+  import 'highlight.js/styles/github-dark.css';
+
+  marked.setOptions({ breaks: true, gfm: true });
+
+  function init(root: HTMLElement) {
+    const form = root.querySelector<HTMLFormElement>('.ask-form')!;
+    const input = root.querySelector<HTMLTextAreaElement>('.ask-input')!;
+    const sendBtn = root.querySelector<HTMLButtonElement>('.ask-send')!;
+    const thread = root.querySelector<HTMLDivElement>('.ask-thread')!;
+    const empty = root.querySelector<HTMLDivElement>('.ask-empty');
+    const endpoint = root.dataset.endpoint!;
+
+    // In dev, route through the Vite proxy to dodge CORS. In prod, hit the
+    // endpoint directly (requires CORS headers on the endpoint).
+    const isDev = import.meta.env.DEV;
+
+    root.querySelectorAll<HTMLButtonElement>('.ask-chip-suggest').forEach((chip) => {
+      chip.addEventListener('click', () => {
+        input.value = chip.textContent ?? '';
+        form.requestSubmit();
+      });
+    });
+
+    // Auto-grow the textarea up to a cap.
+    input.addEventListener('input', autoGrow);
+    function autoGrow() {
+      input.style.height = 'auto';
+      input.style.height = Math.min(input.scrollHeight, 160) + 'px';
+    }
+
+    // Enter sends; Shift+Enter inserts a newline. Ignore Enter while an IME
+    // composition is active (e.g. confirming a Korean/Japanese character),
+    // otherwise the last composing character gets left in the input.
+    let composing = false;
+    input.addEventListener('compositionstart', () => {
+      composing = true;
+    });
+    input.addEventListener('compositionend', () => {
+      composing = false;
+    });
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey && !composing && !e.isComposing) {
+        e.preventDefault();
+        form.requestSubmit();
+      }
+    });
+
+    let running = false;
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const prompt = input.value.trim();
+      if (!prompt || running) return;
+      input.value = '';
+      autoGrow();
+      await ask(prompt);
+    });
+
+    async function ask(prompt: string) {
+      running = true;
+      root.classList.add('is-running');
+      sendBtn.disabled = true;
+
+      if (empty && empty.parentElement) empty.remove();
+
+      renderUser(prompt);
+      const turn = renderAssistant();
+      let raw = '';
+
+      try {
+        const url = isDev
+          ? `/ask-api?prompt=${encodeURIComponent(prompt)}`
+          : `${endpoint}?prompt=${encodeURIComponent(prompt)}`;
+
+        const res = await fetch(url, { headers: { Accept: 'text/event-stream' } });
+        if (!res.ok || !res.body) {
+          throw new Error(`Request failed: ${res.status}`);
+        }
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let stop = false;
+
+        while (!stop) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          // SSE frames are separated by blank lines.
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop() ?? '';
+
+          for (const frame of frames) {
+            const line = frame.trim();
+            if (!line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+
+            if (payload === '[DONE]') {
+              stop = true;
+              break;
+            }
+
+            let delta = '';
+            try {
+              delta = JSON.parse(payload).delta ?? '';
+            } catch {
+              continue;
+            }
+
+            if (delta.startsWith('[TOOL]')) {
+              showTool(turn, delta.replace('[TOOL]', '').trim());
+              continue;
+            }
+
+            // First answer text: tools are done, collapse the trace and hide dots.
+            finalizeSteps(turn);
+            if (turn.thinking.parentElement) turn.thinking.remove();
+            raw += delta;
+            turn.answer.innerHTML = await marked.parse(raw);
+            highlight(turn.answer);
+            scrollToBottom();
+          }
+        }
+
+        if (turn.thinking.parentElement) turn.thinking.remove();
+        if (!raw.trim()) {
+          turn.answer.innerHTML = '<p class="ask-muted">No response.</p>';
+        }
+      } catch (err) {
+        if (turn.thinking.parentElement) turn.thinking.remove();
+        turn.answer.innerHTML = `<p class="ask-error">Failed to get a response: ${
+          err instanceof Error ? err.message : 'unknown error'
+        }</p>`;
+      } finally {
+        finalizeSteps(turn);
+        running = false;
+        root.classList.remove('is-running');
+        sendBtn.disabled = false;
+        input.focus();
+        scrollToBottom();
+      }
+    }
+
+    function renderUser(prompt: string) {
+      const msg = document.createElement('div');
+      msg.className = 'ask-msg ask-msg-user';
+      msg.innerHTML = `
+        <span class="ask-label ask-label-q">Q</span>
+        <div class="ask-question">${escapeHtml(prompt)}</div>
+      `;
+      thread.appendChild(msg);
+      scrollToBottom();
+    }
+
+    function renderAssistant() {
+      const msg = document.createElement('div');
+      msg.className = 'ask-msg ask-msg-bot';
+      msg.innerHTML = `
+        <span class="ask-label ask-label-a">A</span>
+        <div class="ask-content">
+          <div class="ask-steps" hidden>
+            <button type="button" class="ask-steps-head" aria-expanded="true">
+              <span class="ask-steps-caret">${caretSvg()}</span>
+              <span class="ask-steps-spin"><span class="ask-tool-spinner"></span></span>
+              <span class="ask-steps-title">Searching the codebase</span>
+              <span class="ask-steps-count"></span>
+            </button>
+            <ol class="ask-steps-list"></ol>
+          </div>
+          <div class="ask-thinking"><span></span><span></span><span></span></div>
+          <div class="ask-answer"></div>
+        </div>
+      `;
+      thread.appendChild(msg);
+
+      const stepsEl = msg.querySelector<HTMLDivElement>('.ask-steps')!;
+      const headEl = msg.querySelector<HTMLButtonElement>('.ask-steps-head')!;
+      headEl.addEventListener('click', () => {
+        const open = stepsEl.classList.toggle('collapsed');
+        headEl.setAttribute('aria-expanded', String(!open));
+      });
+
+      scrollToBottom();
+      return {
+        el: msg,
+        steps: stepsEl,
+        stepsHead: headEl,
+        stepsList: msg.querySelector<HTMLOListElement>('.ask-steps-list')!,
+        stepsCount: msg.querySelector<HTMLSpanElement>('.ask-steps-count')!,
+        thinking: msg.querySelector<HTMLDivElement>('.ask-thinking')!,
+        answer: msg.querySelector<HTMLDivElement>('.ask-answer')!,
+        lastTool: '',
+        lastItem: null as HTMLLIElement | null,
+        toolCount: 0,
+      };
+    }
+
+    type Turn = ReturnType<typeof renderAssistant>;
+
+    function showTool(turn: Turn, name: string) {
+      turn.steps.hidden = false;
+      turn.toolCount += 1;
+
+      // Each call is its own row: the previous one flips to a check, the new
+      // one spins. A steady stream of completed checks makes progress obvious.
+      markStepDone(turn.lastItem);
+
+      const item = document.createElement('li');
+      item.className = 'ask-step running';
+      item.innerHTML = `
+        <span class="ask-step-icon ask-step-icon-run"><span class="ask-tool-spinner"></span></span>
+        <span class="ask-step-icon ask-step-icon-done">${checkSvg()}</span>
+        <code class="ask-step-name">${escapeHtml(name)}</code>
+      `;
+      turn.stepsList.appendChild(item);
+      turn.lastTool = name;
+      turn.lastItem = item;
+      bumpCount(turn);
+      scrollSteps(turn);
+      scrollToBottom();
+    }
+
+    function bumpCount(turn: Turn) {
+      turn.stepsCount.textContent = `${turn.toolCount} ${
+        turn.toolCount === 1 ? 'call' : 'calls'
+      }`;
+    }
+
+    function scrollSteps(turn: Turn) {
+      turn.stepsList.scrollTop = turn.stepsList.scrollHeight;
+    }
+
+    function markStepDone(item: HTMLLIElement | null) {
+      if (!item) return;
+      item.classList.remove('running');
+      item.classList.add('done');
+    }
+
+    // Mark steps complete and auto-collapse the panel. Called as soon as the
+    // first answer text arrives, so the trace folds away once tools finish.
+    function finalizeSteps(turn: Turn) {
+      markStepDone(turn.lastItem);
+      if (turn.toolCount > 0) {
+        turn.steps.classList.add('settled');
+        const title = turn.steps.querySelector('.ask-steps-title')!;
+        title.textContent = `Searched the codebase`;
+        if (!turn.steps.classList.contains('collapsed')) {
+          turn.steps.classList.add('collapsed');
+          turn.stepsHead.setAttribute('aria-expanded', 'false');
+        }
+      }
+    }
+
+    function caretSvg() {
+      return `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>`;
+    }
+
+    function checkSvg() {
+      return `<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+    }
+
+    function highlight(container: HTMLElement) {
+      container.querySelectorAll<HTMLElement>('pre code').forEach((block) => {
+        if (block.dataset.highlighted) return;
+        hljs.highlightElement(block);
+      });
+    }
+
+    function scrollToBottom() {
+      thread.scrollTop = thread.scrollHeight;
+    }
+
+    function escapeHtml(s: string) {
+      return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+  }
+
+  document.querySelectorAll<HTMLElement>('.ask-chat').forEach(init);
+</script>
+
+<style is:global>
+  .ask-disabled {
+    color: var(--sl-color-gray-3);
+    font-style: italic;
+  }
+  .ask-chat {
+    display: flex;
+    flex-direction: column;
+    height: min(82vh, 900px);
+    margin: 1.5rem 0;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    background: var(--sl-color-bg);
+    overflow: hidden;
+    font-size: 0.95rem;
+  }
+
+  /* Thread (scrollable message list) */
+  .ask-thread {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+  }
+
+  .ask-thread::-webkit-scrollbar {
+    width: 8px;
+  }
+  .ask-thread::-webkit-scrollbar-thumb {
+    background: var(--sl-color-gray-5);
+    border-radius: 4px;
+  }
+
+  /* Empty state */
+  .ask-empty {
+    margin: auto;
+    text-align: center;
+    max-width: 30rem;
+    padding: 1rem;
+  }
+  .ask-empty-title {
+    margin: 0;
+    font-weight: 600;
+    font-size: 1rem;
+    color: var(--sl-color-white);
+  }
+  .ask-empty-sub {
+    margin: 0.35rem 0 1.25rem;
+    font-size: 0.85rem;
+    color: var(--sl-color-gray-3);
+  }
+  .ask-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+  }
+  .ask-chip-suggest {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: 0.4rem;
+    border: 1px solid var(--sl-color-gray-5);
+    background: var(--sl-color-gray-7, var(--sl-color-bg));
+    color: var(--sl-color-gray-2);
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease;
+  }
+  .ask-chip-suggest:hover {
+    border-color: var(--sl-color-accent);
+    color: var(--sl-color-white);
+  }
+
+  /* Messages: Q / A rows sharing a hanging label column */
+  .ask-msg {
+    display: grid;
+    grid-template-columns: 1.6rem 1fr;
+    gap: 0.75rem;
+    animation: ask-fade 0.2s ease;
+  }
+  @keyframes ask-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .ask-label {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: start;
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 0.3rem;
+    font-family: var(--sl-font-mono, monospace);
+    font-size: 0.72rem;
+    font-weight: 700;
+    user-select: none;
+    box-sizing: border-box;
+  }
+  /* A first text line has a tall line box (1.6 line-height, taller still with an
+     emoji), so its glyph centre sits well below a top-aligned square label.
+     These nudges drop each label to line up with its first line of text. */
+  .ask-label-q {
+    color: var(--sl-color-gray-2);
+    border: 1px solid var(--sl-color-gray-5);
+    margin-top: 0.18rem;
+  }
+  .ask-label-a {
+    /* Fixed white: Starlight's --sl-color-white inverts to a dark color in
+       light theme, which would vanish against the accent background. */
+    color: #fff;
+    background: var(--sl-color-accent);
+    margin-top: 0.3rem;
+  }
+
+  .ask-question {
+    color: var(--sl-color-text-accent, var(--sl-color-accent));
+    font-weight: 700;
+    font-size: 1.2rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .ask-content {
+    min-width: 0;
+  }
+
+  .ask-answer {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--sl-color-gray-1, var(--sl-color-white));
+  }
+  .ask-answer > *:first-child {
+    margin-top: 0;
+  }
+  .ask-answer > *:last-child {
+    margin-bottom: 0;
+  }
+  .ask-answer pre {
+    border-radius: 0.5rem;
+    border: 1px solid var(--sl-color-gray-5);
+    font-size: 0.85em;
+  }
+  .ask-answer :not(pre) > code {
+    font-size: 0.88em;
+    padding: 0.1rem 0.35rem;
+    border-radius: 0.3rem;
+    background: var(--sl-color-gray-6);
+  }
+
+  /* Steps panel (collapsible tool-execution trace) */
+  .ask-steps {
+    margin-bottom: 0.85rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    background: var(--sl-color-gray-7, var(--sl-color-bg));
+    overflow: hidden;
+  }
+  .ask-steps[hidden] {
+    display: none;
+  }
+  .ask-steps-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: none;
+    background: transparent;
+    color: var(--sl-color-gray-1, var(--sl-color-white));
+    font-size: 0.82rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: left;
+  }
+  .ask-steps-caret {
+    display: inline-flex;
+    color: var(--sl-color-gray-3);
+    transition: transform 0.2s ease;
+  }
+  .ask-steps.collapsed .ask-steps-caret {
+    transform: rotate(-90deg);
+  }
+  /* Header spinner: visible only while tools are still running. */
+  .ask-steps-spin {
+    display: inline-flex;
+    align-items: center;
+  }
+  .ask-steps.settled .ask-steps-spin {
+    display: none;
+  }
+  .ask-steps-title {
+    flex-shrink: 0;
+  }
+  .ask-steps-count {
+    margin-left: auto;
+    font-size: 0.72rem;
+    font-weight: 400;
+    color: var(--sl-color-gray-3);
+    font-family: var(--sl-font-mono, monospace);
+  }
+  .ask-steps-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.15rem 0.75rem 0.6rem;
+    border-top: 1px solid var(--sl-color-gray-5);
+    max-height: 9.5rem;
+    overflow-y: auto;
+    scroll-behavior: smooth;
+  }
+  .ask-steps-list::-webkit-scrollbar {
+    width: 6px;
+  }
+  .ask-steps-list::-webkit-scrollbar-thumb {
+    background: var(--sl-color-gray-5);
+    border-radius: 3px;
+  }
+  .ask-steps.collapsed .ask-steps-list {
+    display: none;
+  }
+  .ask-step {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.3rem 0;
+    font-size: 0.8rem;
+    color: var(--sl-color-gray-2);
+    animation: ask-fade 0.2s ease;
+  }
+  .ask-step.running .ask-step-name {
+    color: var(--sl-color-white);
+  }
+  .ask-step-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.1rem;
+    height: 1.1rem;
+    flex-shrink: 0;
+  }
+  .ask-step-icon-done {
+    border-radius: 50%;
+    color: #fff;
+    background: var(--sl-color-accent);
+  }
+  .ask-step .ask-step-icon-done { display: none; }
+  .ask-step.done .ask-step-icon-run { display: none; }
+  .ask-step.done .ask-step-icon-done { display: inline-flex; }
+  .ask-step.done {
+    color: var(--sl-color-gray-3);
+  }
+  .ask-step-name {
+    font-family: var(--sl-font-mono, monospace);
+    font-size: 0.78rem;
+    background: none;
+    padding: 0;
+    color: inherit;
+    word-break: break-all;
+  }
+  .ask-tool-spinner {
+    width: 0.65rem;
+    height: 0.65rem;
+    border: 2px solid var(--sl-color-gray-4);
+    border-top-color: var(--sl-color-accent);
+    border-radius: 50%;
+    animation: ask-spin 0.7s linear infinite;
+  }
+  @keyframes ask-spin {
+    to { transform: rotate(360deg); }
+  }
+
+  /* Thinking dots */
+  .ask-thinking {
+    display: flex;
+    gap: 0.3rem;
+    padding: 0.3rem 0;
+  }
+  .ask-thinking span {
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: var(--sl-color-gray-4);
+    animation: ask-bounce 1.2s infinite ease-in-out;
+  }
+  .ask-thinking span:nth-child(2) { animation-delay: 0.15s; }
+  .ask-thinking span:nth-child(3) { animation-delay: 0.3s; }
+  @keyframes ask-bounce {
+    0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+    30% { transform: translateY(-0.3rem); opacity: 1; }
+  }
+
+  .ask-error { color: var(--sl-color-red, #f87171); }
+  .ask-muted { color: var(--sl-color-gray-3); }
+
+  /* Composer (bottom-fixed input, terminal-prompt feel) */
+  .ask-form {
+    display: flex;
+    gap: 0.6rem;
+    align-items: flex-end;
+    padding: 0.75rem 1rem;
+    border-top: 1px solid var(--sl-color-gray-5);
+    background: var(--sl-color-gray-7, var(--sl-color-bg));
+  }
+  .ask-prompt-mark {
+    font-family: var(--sl-font-mono, monospace);
+    font-weight: 700;
+    color: var(--sl-color-accent);
+    line-height: 2.2;
+    user-select: none;
+  }
+  .ask-input {
+    flex: 1;
+    resize: none;
+    border: none;
+    background: transparent;
+    color: var(--sl-color-white);
+    font-size: 0.95rem;
+    font-family: inherit;
+    line-height: 1.6;
+    padding: 0.5rem 0;
+    outline: none;
+    max-height: 160px;
+  }
+  .ask-input::placeholder {
+    color: var(--sl-color-gray-4);
+  }
+  .ask-send {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.2rem;
+    height: 2.2rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.4rem;
+    background: transparent;
+    color: var(--sl-color-gray-2);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: border-color 0.15s ease, color 0.15s ease;
+  }
+  .ask-send:hover:not(:disabled) {
+    border-color: var(--sl-color-accent);
+    color: var(--sl-color-white);
+  }
+  .ask-send:disabled {
+    cursor: default;
+  }
+  .ask-send-stop {
+    display: none;
+    width: 0.8rem;
+    height: 0.8rem;
+    border: 2px solid var(--sl-color-gray-4);
+    border-top-color: var(--sl-color-accent);
+    border-radius: 50%;
+    animation: ask-spin 0.7s linear infinite;
+  }
+  .ask-chat.is-running .ask-send-icon { display: none; }
+  .ask-chat.is-running .ask-send-stop { display: block; }
+
+  @media (max-width: 640px) {
+    .ask-chat { height: min(80vh, 640px); }
+    .ask-thread { padding: 1rem; }
+  }
+</style>

--- a/docs/src/components/AskPageSidebar.astro
+++ b/docs/src/components/AskPageSidebar.astro
@@ -1,0 +1,141 @@
+---
+// Right-sidebar override. The "Ask AI" page has only a single-entry table of
+// contents, so we replace it with a short note about what powers the chat and
+// a link to the repo. Styled to match the default TOC (small, muted text).
+// Every other page keeps the default sidebar/TOC.
+import Default from '@astrojs/starlight/components/PageSidebar.astro';
+
+const route = Astro.locals.starlightRoute;
+const id = route.id ?? '';
+const isAsk = id === 'ask' || id.endsWith('/ask');
+const locale = route.locale ?? 'en';
+
+const REPO_URL = 'https://github.com/aws-samples/sample-reusable-assets-toolkit';
+
+const t = {
+  en: {
+    heading: 'Powered by',
+    lead: 'Answers are grounded in this repository, indexed and made searchable by the Reusable Asset Toolkit (rat) — a toolkit for discovering and reusing code assets across an organization.',
+    items: [
+      'Source is parsed into an AST with tree-sitter and split into meaningful units — functions, classes, structs — keeping their doc comments and decorators.',
+      'Each chunk is enriched with LLM-generated descriptions, so code is searchable by intent rather than exact keywords.',
+      'Hybrid search (vector embeddings + keyword ranking) surfaces relevant snippets, even from unfamiliar repositories.',
+      'The same index is exposed over an MCP server, so AI coding assistants (Claude Code, Kiro, …) can pull validated code patterns straight into the conversation.',
+      'Indexing runs on a Git repo and is incremental — only changed files are re-processed, with .ratignore to exclude paths.',
+    ],
+    repoLabel: 'Learn more',
+    repo: 'Reusable Asset Toolkit',
+  },
+  ko: {
+    heading: '기반 기술',
+    lead: '답변은 Reusable Asset Toolkit(rat)이 색인·검색하는 이 저장소의 코드를 근거로 합니다. 조직 전반의 코드 자산을 발견하고 재사용하기 위한 툴킷입니다.',
+    items: [
+      'tree-sitter로 소스를 AST로 파싱해 함수·클래스·구조체 등 의미 단위로 청킹하며, 해당 doc 주석과 데코레이터를 함께 보존합니다.',
+      '각 청크에 LLM이 생성한 설명을 덧붙여, 정확한 키워드가 아닌 의도(intent)로 검색됩니다.',
+      '하이브리드 검색(벡터 임베딩 + 키워드 랭킹)으로 익숙하지 않은 저장소에서도 관련 코드 조각을 찾아냅니다.',
+      '동일한 색인을 MCP 서버로 노출해, AI 코딩 어시스턴트(Claude Code, Kiro 등)가 검증된 코드 패턴을 대화에 바로 가져옵니다.',
+      'Git 저장소 단위로 색인하며 증분 방식으로 동작합니다. 변경된 파일만 재처리하고, .ratignore로 경로를 제외할 수 있습니다.',
+    ],
+    repoLabel: '자세히 보기',
+    repo: 'Reusable Asset Toolkit',
+  },
+  ja: {
+    heading: '基盤',
+    lead: '回答は、Reusable Asset Toolkit (rat) がインデックス化・検索するこのリポジトリのコードに基づきます。組織全体のコード資産を発見・再利用するためのツールキットです。',
+    items: [
+      'tree-sitter でソースを AST に解析し、関数・クラス・構造体などの意味単位にチャンク化します（doc コメントやデコレーターも保持）。',
+      '各チャンクに LLM 生成の説明を付与し、正確なキーワードではなく意図（intent）で検索できます。',
+      'ハイブリッド検索（ベクトル埋め込み + キーワードランキング）で、馴染みのないリポジトリからも関連スニペットを見つけます。',
+      '同じインデックスを MCP サーバーで公開し、AI コーディングアシスタント（Claude Code、Kiro など）が検証済みコードパターンを会話に直接取り込めます。',
+      'Git リポジトリ単位でインデックス化し、増分で動作します。変更ファイルのみ再処理し、.ratignore でパスを除外できます。',
+    ],
+    repoLabel: '詳しく見る',
+    repo: 'Reusable Asset Toolkit',
+  },
+};
+
+const c = t[locale] ?? t.en;
+---
+
+{
+  isAsk ? (
+    <div class="ask-toc">
+      <h2 class="ask-toc-heading">{c.heading}</h2>
+      <p class="ask-toc-lead">{c.lead}</p>
+      <ul class="ask-toc-list">
+        {c.items.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
+      <a class="ask-toc-link" href={REPO_URL} target="_blank" rel="noopener">
+        {c.repoLabel}: {c.repo} &nearr;
+      </a>
+    </div>
+  ) : (
+    <Default {...Astro.props}>
+      <slot />
+    </Default>
+  )
+}
+
+<style is:global>
+  .ask-toc {
+    /* Sits directly in .right-sidebar with no inner container, so without an
+       explicit width the long text expands the sidebar past the viewport edge.
+       Pin it to the TOC column width and let text wrap inside. */
+    box-sizing: border-box;
+    width: var(--sl-sidebar-width, 18rem);
+    max-width: 100%;
+    padding: 1.5rem 1rem 0;
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+  .ask-toc-heading {
+    font-size: var(--sl-text-h5);
+    font-weight: 600;
+    color: var(--sl-color-white);
+    margin: 0 0 0.5rem;
+  }
+  .ask-toc-list {
+    list-style: none;
+    margin: 0 0 1rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .ask-toc-list li {
+    position: relative;
+    padding-left: 0.85rem;
+    font-size: var(--sl-text-xs);
+    line-height: 1.5;
+    color: var(--sl-color-gray-3);
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+  .ask-toc-list li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.5em;
+    width: 0.3rem;
+    height: 0.3rem;
+    border-radius: 50%;
+    background: var(--sl-color-gray-4);
+  }
+  .ask-toc-lead {
+    font-size: var(--sl-text-xs);
+    line-height: 1.5;
+    color: var(--sl-color-gray-3);
+    margin: 0 0 0.75rem;
+    overflow-wrap: break-word;
+  }
+  .ask-toc-link {
+    font-size: var(--sl-text-xs);
+    color: var(--sl-color-text-accent);
+    text-decoration: none;
+  }
+  .ask-toc-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/docs/src/content/docs/en/ask.mdx
+++ b/docs/src/content/docs/en/ask.mdx
@@ -1,0 +1,12 @@
+---
+title: "Ask AI"
+description: "Ask questions about the AWS IDP Pipeline repository and get streaming, AI-powered answers."
+prev: false
+next: false
+---
+
+import AskChat from '../../../components/AskChat.astro';
+
+Ask anything about this repository. Answers stream in real time.
+
+<AskChat />

--- a/docs/src/content/docs/ja/ask.mdx
+++ b/docs/src/content/docs/ja/ask.mdx
@@ -1,0 +1,12 @@
+---
+title: "AIに質問"
+description: "AWS IDP Pipeline リポジトリについて質問し、AI によるストリーミング回答を受け取れます。"
+prev: false
+next: false
+---
+
+import AskChat from '../../../components/AskChat.astro';
+
+このリポジトリについて何でも質問してください。回答はリアルタイムでストリーミングされます。
+
+<AskChat />

--- a/docs/src/content/docs/ko/ask.mdx
+++ b/docs/src/content/docs/ko/ask.mdx
@@ -1,0 +1,12 @@
+---
+title: "AI에게 물어보기"
+description: "AWS IDP Pipeline 저장소에 대해 질문하고 AI가 실시간으로 스트리밍하는 답변을 받아보세요."
+prev: false
+next: false
+---
+
+import AskChat from '../../../components/AskChat.astro';
+
+이 저장소에 대해 무엇이든 질문해 보세요. 답변은 실시간으로 스트리밍됩니다.
+
+<AskChat />

--- a/packages/infra/src/stacks/workflow-stack.ts
+++ b/packages/infra/src/stacks/workflow-stack.ts
@@ -167,7 +167,7 @@ export class WorkflowStack extends Stack {
       );
 
       return lambda.Code.fromAsset(layerDir, {
-        assetHashType: AssetHashType.OUTPUT,
+        assetHashType: AssetHashType.SOURCE,
         bundling: {
           image: lambda.Runtime.PYTHON_3_14.bundlingImage,
           command: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,13 +351,19 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.37.6
-        version: 0.37.6(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))
+        version: 0.37.6(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2))
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2)
+        version: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2)
       astro-mermaid:
         specifier: ^1.3.1
-        version: 1.3.1(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))(mermaid@11.12.3)
+        version: 1.3.1(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2))(mermaid@11.12.3)
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
+      marked:
+        specifier: ^18.0.5
+        version: 18.0.5
       mermaid:
         specifier: ^11.12.3
         version: 11.12.3
@@ -2370,30 +2376,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@getgrit/gritql-linux-arm64-musl@0.0.3':
     resolution: {integrity: sha512-kkXcMCR/+IaFecTL/QXcCNhWhD89Uns0YkdtsKNIsWMhAH3MJZ9HEEPcVxCIKl3SbWf2EqCMt7CiQ8qYA/ufRw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@getgrit/gritql-linux-riscv64-gnu@0.0.3':
     resolution: {integrity: sha512-TYxMTUomx7p38frux25QYO931R43npIHPHIXGNdJjQ6Et1clmaZVHtByD7rPEI2mFDhnwzIt7hCesFKL+/+88Q==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@getgrit/gritql-linux-x64-gnu@0.0.3':
     resolution: {integrity: sha512-e0CJGV7UWhC859MRcexOVUK5v11ha3qGZk/oPTuHZx1mUybtr3cJQ1V5tCVuH2fM4yzEhTrtLUQGlCH93pWsZA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@getgrit/gritql-linux-x64-musl@0.0.3':
     resolution: {integrity: sha512-+tYPiaf2cEet3HivADhVLYLcS+o66Tka1ccACmrPyIZCD16ZRjiseL2Awg79fIdOvucGKzVgxBuI+zXA6JhQMg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@getgrit/gritql-win32-arm64-msvc@0.0.3':
     resolution: {integrity: sha512-OYQfkXRZbI9tSbe36lFmfdW+FN1aYPGYQFJ7I888gr5BeNPqoLE0TWjpzYvcGceVySg2gjLk35gb62XzjTWmxQ==}
@@ -2494,89 +2505,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2667,24 +2694,28 @@ packages:
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@lancedb/lancedb-linux-arm64-musl@0.23.0':
     resolution: {integrity: sha512-c2UCtGoYjA3oDdw5y3RLK7J2th3rSjYBng+1I03vU9g092y8KATAJO/lV2AtyxSC+esSuyY1dMEaj8ADcXjZAA==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@lancedb/lancedb-linux-x64-gnu@0.23.0':
     resolution: {integrity: sha512-OPL7tK3JCTx43ZxvbVs+CljfCer0KrojANQbcJ2V4VAp6XBhKx1sBAlIVGuCrd93pA8UOUP3iHsM7aglPo6rCg==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@lancedb/lancedb-linux-x64-musl@0.23.0':
     resolution: {integrity: sha512-1ZEoQDwOrKvwPyAG+95/r1NYqX8Ca5bRek8Vr62CzWCEmHd/pFeEGWZ5STrkh+Bt3GLdi2JOivFtRbmuBAJypQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@lancedb/lancedb-win32-arm64-msvc@0.23.0':
     resolution: {integrity: sha512-OuD1mkrgXvijRlXdbx3LvfuorO04FD5qHegnTOWGXh1sIwwrvvhcJAvXUGBNLY4n/lsWvA+xTjtMwRjUitvPKg==}
@@ -2967,30 +2998,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.97':
     resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
     resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.97':
     resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.97':
     resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
     resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
@@ -3049,42 +3085,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -3204,21 +3247,25 @@ packages:
     resolution: {integrity: sha512-uIkPcanSTIcyh7/6LOoX0YpGO/7GkVhMRgyM9Mg/7ItFjCtRaeuPEPrJESsaNeB5zIVVhI4cXbGrM9NDnagiiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.6.1':
     resolution: {integrity: sha512-eqkG8s/7remiRZ1Lo2zIrFLSNsQ/0x9fAj++CV1nqFE+rfykPQhC48F8pqsq6tUQpI5HqRQEfQgv4CnFNpLR+w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.6.1':
     resolution: {integrity: sha512-6DhSupCcDa6BYzQ48qsMK4LIdIO+y4E+4xuUBkX2YTGOZh58gctELCv7Gi6/FhiC8rzVzM7hDcygOvHCGc30zA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.6.1':
     resolution: {integrity: sha512-QqtfaBhdfLRKGucpP8RSv7KJ51XRWpfUcXPhkb/1dKP/b9/Z0kpaCgczGHdrAtX9m6haWw+sQXYGxnStZIg/TQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.6.1':
     resolution: {integrity: sha512-8pTWXphY5IIgY3edZ5SfzP8yPjBqoAxRV5snAYDctF4e0OC1nDOUims70jLesMle8DTSWiHPSfbLVfp2HkU9WQ==}
@@ -3459,131 +3506,157 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -3659,21 +3732,25 @@ packages:
     resolution: {integrity: sha512-fvZX6xZPvBT8qipSpvkKMX5M7yd2BSpZNCZXcefw6gA3uC7LI3gu+er0LrDXY1PtPzVuHTyDx+abwWpagV3PiQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.6.8':
     resolution: {integrity: sha512-++XMKcMNrt59HcFBLnRaJcn70k3X0GwkAegZBVpel8xYIAgvoXT5+L8P1ExId/yTFxqedaz8DbcxQnNmMozviw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.6.8':
     resolution: {integrity: sha512-tv3BWkTE1TndfX+DsE1rSTg8fBevCxujNZ3MlfZ22Wfy9x1FMXTJlWG8VIOXmaaJ1wUHzv8S7cE2YUUJ2LuiCg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.6.8':
     resolution: {integrity: sha512-DCGgZ5/in1O3FjHWqXnDsncRy+48cMhfuUAAUyl0yDj1NpsZu9pP+xfGLvGcQTiYrVl7IH9Aojf1eShP/77WGA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.6.8':
     resolution: {integrity: sha512-VUwdhl/lI4m6o1OGCZ9JwtMjTV/yLY5VZTQdEPKb40JMTlmZ5MBlr5xk7ByaXXYHr6I+qnqEm73iMKQvg6iknw==}
@@ -4227,24 +4304,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.5.29':
     resolution: {integrity: sha512-TERh2OICAJz+SdDIK9+0GyTUwF6r4xDlFmpoiHKHrrD/Hh3u+6Zue0d7jQ/he/i80GDn4tJQkHlZys+RZL5UZg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.5.29':
     resolution: {integrity: sha512-WMDPqU7Ji9dJpA+Llek2p9t7pcy7Bob8ggPUvgsIlv3R/eesF9DIzSbrgl6j3EAEPB9LFdSafsgf6kT/qnvqFg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.5.29':
     resolution: {integrity: sha512-DO14glwpdKY4POSN0201OnGg1+ziaSVr6/RFzuSLggshwXeeyVORiHv3baj7NENhJhWhUy3NZlDsXLnRFkmhHQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.5.29':
     resolution: {integrity: sha512-V3Y1+a1zG1zpYXUMqPIHEMEOd+rHoVnIpO/KTyFwAmKVu8v+/xPEVx/AGoYE67x4vDAAvPQrKI3Aokilqa5yVg==}
@@ -4324,24 +4405,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -5033,6 +5118,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -7477,6 +7563,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
@@ -8155,24 +8245,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -8376,6 +8470,11 @@ packages:
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -10482,6 +10581,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -10490,6 +10590,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -11214,12 +11315,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.13(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))':
+  '@astrojs/mdx@4.3.13(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -11243,17 +11344,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight@0.37.6(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))':
+  '@astrojs/starlight@0.37.6(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
-      '@astrojs/mdx': 4.3.13(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))
+      '@astrojs/mdx': 4.3.13(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2))
       '@astrojs/sitemap': 3.7.0
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2)
-      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))
+      astro: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2)
+      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -18523,20 +18624,20 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2)):
+  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2)):
     dependencies:
-      astro: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2)
       rehype-expressive-code: 0.41.7
 
-  astro-mermaid@1.3.1(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))(mermaid@11.12.3):
+  astro-mermaid@1.3.1(astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2))(mermaid@11.12.3):
     dependencies:
-      astro: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2)
       import-meta-resolve: 4.2.0
       mdast-util-to-string: 4.0.0
       mermaid: 11.12.3
       unist-util-visit: 5.1.0
 
-  astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2):
+  astro@5.18.1(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.46.0)(tsx@4.20.6)(typescript@6.0.2)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -18587,7 +18688,7 @@ snapshots:
       svgo: 4.0.1
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@6.0.2)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -18600,7 +18701,7 @@ snapshots:
       yocto-spinner: 0.2.3
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@6.0.2)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -21043,6 +21144,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  highlight.js@11.11.1: {}
+
   homedir-polyfill@1.0.3:
     dependencies:
       parse-passwd: 1.0.0
@@ -21965,6 +22068,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
+
+  marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -24396,6 +24501,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  tsconfck@3.1.6(typescript@6.0.2):
+    optionalDependencies:
+      typescript: 6.0.2
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -25131,9 +25240,9 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
-  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
+  zod-to-ts@1.2.0(typescript@6.0.2)(zod@3.25.76):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
       zod: 3.25.76
 
   zod@3.25.76: {}


### PR DESCRIPTION
  - docs Starlight 사이트에 'Ask AI' 스트리밍 채팅 페이지 추가 (en/ko/ja)
  - AskChat.astro: SSE 스트리밍 응답, 마크다운/코드 하이라이팅 렌더링
  - 도구 실행을 접을 수 있는 steps 패널로 표시 (응답 시작 시 자동 접힘)
  - 챗 UI 텍스트 다국어화 (제목/추천질문/placeholder), 한글 IME 조합 처리
  - AskPageSidebar.astro: ask 페이지 우측에 rat(Reusable Asset Toolkit) 소개 + GitHub 링크
  - ask.config.mjs로 endpoint/on-off 설정 단일화, dev 프록시로 CORS 우회
  - 사이드바 메뉴 등록, prev/next 네비 숨김, marked·highlight.js 의존성 추가
  - workflow-stack: 레이어 assetHashType을 OUTPUT에서 SOURCE로 변경 (별개 수정)