### PR TITLE
Reduce Ask AI chat height to 70vh

### DIFF
--- a/docs/src/components/AskChat.astro
+++ b/docs/src/components/AskChat.astro
@@ -387,7 +387,7 @@ const u = ui[locale] ?? ui.en;
   .ask-chat {
     display: flex;
     flex-direction: column;
-    height: min(82vh, 900px);
+    height: min(70vh, 900px);
     margin: 1.5rem 0;
     border: 1px solid var(--sl-color-gray-5);
     border-radius: 0.5rem;
@@ -742,7 +742,7 @@ const u = ui[locale] ?? ui.en;
   .ask-chat.is-running .ask-send-stop { display: block; }
 
   @media (max-width: 640px) {
-    .ask-chat { height: min(80vh, 640px); }
+    .ask-chat { height: min(70vh, 640px); }
     .ask-thread { padding: 1rem; }
   }
 </style>


### PR DESCRIPTION
  - AskChat 챗 영역 높이를 82vh에서 70vh로 축소 (데스크톱)
  - 모바일 높이도 80vh에서 70vh로 통일