### PR TITLE
fix: prevent SQL injection in chat history query

### DIFF
--- a/packages/backend/app/routers/chat.py
+++ b/packages/backend/app/routers/chat.py
@@ -77,17 +77,20 @@ def get_chat_history(
 
     conn = get_duckdb_connection()
     try:
-        result = conn.execute(f"""
+        result = conn.execute(
+            """
             SELECT
                 message_id,
                 message.role as role,
                 message.content as content,
                 created_at,
                 updated_at
-            FROM read_json_auto('{s3_path}')
+            FROM read_json_auto(?)
             WHERE message.role IN ('user', 'assistant')
             ORDER BY message_id
-        """).fetchall()
+            """,
+            [s3_path],
+        ).fetchall()
     except Exception:
         return ChatHistoryResponse(session_id=session_id, messages=[])
 


### PR DESCRIPTION
## 변경 내용

`get_chat_history`에서 `read_json_auto()`의 S3 경로를 f-string으로 SQL 문자열에 직접 끼워넣던 것을 DuckDB 파라미터 바인딩(`?`)으로 변경했습니다.

## 배경

`s3_path`를 구성하는 `x_user_id`(요청 헤더), `project_id`/`session_id`(path 파라미터)가 모두 외부 입력이라, 작은따옴표 등을 통해 `read_json_auto('...')`의 문자열 리터럴을 탈출하는 SQL injection이 가능했습니다. 파라미터 바인딩으로 원천 차단합니다.

## 테스트

- 기존 동작 변경 없음 (쿼리 결과 동일)