### PR TITLE
Replace DuckDuckGo with AgentCore Web Search

### DIFF
--- a/packages/agents/bidi-agent/agents/__init__.py
+++ b/packages/agents/bidi-agent/agents/__init__.py
@@ -1,3 +1,3 @@
-from .bidi_agent import get_duckduckgo_mcp_client, get_mcp_client, get_tools
+from .bidi_agent import get_mcp_client, get_tools
 
-__all__ = ["get_duckduckgo_mcp_client", "get_mcp_client", "get_tools"]
+__all__ = ["get_mcp_client", "get_tools"]

--- a/packages/agents/bidi-agent/agents/bidi_agent.py
+++ b/packages/agents/bidi-agent/agents/bidi_agent.py
@@ -7,24 +7,10 @@ import boto3
 import pytz
 from strands.tools.mcp.mcp_client import MCPClient
 
-from mcp import StdioServerParameters
-from mcp.client.stdio import stdio_client
-
 from agentcore_mcp_client import AgentCoreGatewayMCPClient
 from config import get_config
 
 logger = logging.getLogger(__name__)
-
-
-def get_duckduckgo_mcp_client() -> MCPClient:
-    """Get MCP client for DuckDuckGo search server."""
-    return MCPClient(
-        lambda: stdio_client(
-            StdioServerParameters(
-                command="duckduckgo-mcp-server",
-            )
-        )
-    )
 
 
 def get_mcp_client() -> MCPClient | None:
@@ -72,14 +58,20 @@ async def get_date_and_time(tool_input: dict, context: dict) -> dict:
 BUILTIN_TOOLS = [
     {
         "name": "getDateAndTimeTool",
-        "description": "Get the current date and time. Use this when the user asks about the current time, date, day of week, or any time-related questions.",
+        "description": (
+            "Get the current date and time. Use this when the user asks about the current time, "
+            "date, day of week, or any time-related questions."
+        ),
         "inputSchema": {
             "json": {
                 "type": "object",
                 "properties": {
                     "timezone": {
                         "type": "string",
-                        "description": "IANA timezone name (e.g., 'Asia/Seoul', 'America/New_York', 'UTC'). Use the user's timezone if known.",
+                        "description": (
+                            "IANA timezone name (e.g., 'Asia/Seoul', 'America/New_York', 'UTC'). "
+                            "Use the user's timezone if known."
+                        ),
                     }
                 },
                 "required": [],

--- a/packages/agents/bidi-agent/main.py
+++ b/packages/agents/bidi-agent/main.py
@@ -57,13 +57,35 @@ Reference: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime
 import asyncio
 import json
 import logging
+import os
 import sys
-from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from contextlib import asynccontextmanager, suppress
+from datetime import UTC, datetime
 
 import boto3
-
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from strands.experimental.bidi.models.model import BidiModelTimeoutError
+from strands.experimental.bidi.types.events import (
+    BidiAudioInputEvent,
+    BidiAudioStreamEvent,
+    BidiConnectionStartEvent,
+    BidiErrorEvent,
+    BidiInterruptionEvent,
+    BidiResponseCompleteEvent,
+    BidiResponseStartEvent,
+    BidiTextInputEvent,
+    BidiTranscriptStreamEvent,
+    ToolUseStreamEvent,
+)
+from strands.session import S3SessionManager
+from strands.types._events import ToolResultEvent
+from strands.types.content import ContentBlock, Message
+from strands.types.session import SessionMessage
+from websockets.exceptions import ConnectionClosedError
+
+from agents import get_mcp_client, get_tools
+from agents.bidi_agent import execute_builtin_tool
+from config import create_bidi_model, get_config
 
 # Configure logging to stdout for CloudWatch
 logging.basicConfig(
@@ -76,40 +98,17 @@ logging.basicConfig(
 # Startup verification log
 print("=" * 50, flush=True)
 print("[BIDI-AGENT] Module loaded - logging initialized", flush=True)
-print(f"[BIDI-AGENT] Python buffering: PYTHONUNBUFFERED={__import__('os').environ.get('PYTHONUNBUFFERED', 'NOT SET')}", flush=True)
+print(f"[BIDI-AGENT] Python buffering: PYTHONUNBUFFERED={os.environ.get('PYTHONUNBUFFERED', 'NOT SET')}", flush=True)
 print("=" * 50, flush=True)
-
-from strands.experimental.bidi.models.model import BidiModelTimeoutError
-from websockets.exceptions import ConnectionClosedError
-from strands.experimental.bidi.types.events import (
-    BidiTextInputEvent,
-    BidiAudioInputEvent,
-    BidiAudioStreamEvent,
-    BidiTranscriptStreamEvent,
-    BidiConnectionStartEvent,
-    BidiResponseStartEvent,
-    BidiResponseCompleteEvent,
-    BidiInterruptionEvent,
-    BidiErrorEvent,
-    ToolUseStreamEvent,
-)
-from strands.session import S3SessionManager
-from strands.types.content import ContentBlock, Message
-from strands.types.session import SessionMessage
-from strands.types._events import ToolResultEvent
-
-from config import get_config, create_bidi_model
-from agents import get_mcp_client, get_duckduckgo_mcp_client, get_tools
-from agents.bidi_agent import execute_builtin_tool
 
 logger = logging.getLogger(__name__)
 
 # Global MCP client and tools (initialized at startup)
 mcp_client = None
-duckduckgo_client = None
 mcp_tools = []
-duckduckgo_tools = []
-duckduckgo_tool_names = set()
+# Gateway tool names that accept auto-injected user_id/project_id (e.g. search, qa).
+# Tools without those parameters (e.g. WebSearch) are excluded so injection is skipped.
+mcp_injectable_names = set()
 
 
 def convert_mcp_tool_to_bidi_format(tool) -> dict:
@@ -151,27 +150,11 @@ def convert_mcp_tool_to_bidi_format(tool) -> dict:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Load MCP tools and DuckDuckGo tools at startup."""
-    global mcp_client, duckduckgo_client, mcp_tools, duckduckgo_tools, duckduckgo_tool_names
+    """Load MCP tools from the AgentCore Gateway at startup."""
+    global mcp_client, mcp_tools, mcp_injectable_names
 
-    # Initialize DuckDuckGo MCP client
-    try:
-        duckduckgo_client = get_duckduckgo_mcp_client()
-        duckduckgo_client.__enter__()
-        raw_ddg_tools = duckduckgo_client.list_tools_sync()
-        for t in raw_ddg_tools:
-            try:
-                converted = convert_mcp_tool_to_bidi_format(t)
-                duckduckgo_tools.append(converted)
-                duckduckgo_tool_names.add(converted["name"])
-            except Exception as e:
-                logger.error(f"Failed to convert DuckDuckGo tool: {e}")
-        logger.info(f"Loaded {len(duckduckgo_tools)} DuckDuckGo tools: {[t['name'] for t in duckduckgo_tools]}")
-    except Exception as e:
-        logger.error(f"Failed to load DuckDuckGo tools: {e}")
-        duckduckgo_client = None
-
-    # Initialize AgentCore MCP client
+    # Initialize AgentCore MCP client. The gateway exposes document tools
+    # (search, qa) and the built-in WebSearch tool.
     config = get_config()
     if config.mcp_gateway_url:
         logger.info(f"Connecting to MCP Gateway: {config.mcp_gateway_url}")
@@ -182,8 +165,13 @@ async def lifespan(app: FastAPI):
                 raw_tools = mcp_client.list_tools_sync()
                 for t in raw_tools:
                     try:
+                        raw_schema = t.tool_spec.get("inputSchema", {}) if hasattr(t, "tool_spec") else {}
+                        raw_props = raw_schema.get("json", raw_schema).get("properties", {})
                         converted = convert_mcp_tool_to_bidi_format(t)
-                        logger.info(f"MCP tool converted: {converted['name']} -> inputSchema keys: {list(converted.get('inputSchema', {}).get('json', {}).keys())}")
+                        if "user_id" in raw_props or "project_id" in raw_props:
+                            mcp_injectable_names.add(converted["name"])
+                        schema_keys = list(converted.get("inputSchema", {}).get("json", {}).keys())
+                        logger.info(f"MCP tool converted: {converted['name']} -> inputSchema keys: {schema_keys}")
                         mcp_tools.append(converted)
                     except Exception as e:
                         logger.error(f"Failed to convert MCP tool: {e}")
@@ -195,13 +183,6 @@ async def lifespan(app: FastAPI):
         logger.warning("MCP_GATEWAY_URL not set, running without MCP tools")
 
     yield
-
-    if duckduckgo_client:
-        try:
-            duckduckgo_client.__exit__(None, None, None)
-            logger.info("DuckDuckGo client closed")
-        except Exception as e:
-            logger.error(f"Error closing DuckDuckGo client: {e}")
 
     if mcp_client:
         try:
@@ -244,7 +225,7 @@ class TranscriptSaver:
         if not self.enabled or not self.session_manager:
             return
 
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
 
         try:
             message = Message(
@@ -272,7 +253,7 @@ class TranscriptSaver:
         if not self.enabled or not self.session_manager:
             return
 
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
 
         try:
             message = Message(
@@ -336,7 +317,9 @@ Korean Language Understanding:
 LANGUAGE_MIRROR_PROMPT = """
 CRITICAL LANGUAGE MIRRORING RULES:
 - Always reply in the language spoken. DO NOT mix with English. However, if the user talks in English, reply in English.
-- Please respond in the language the user is talking to you in, If you have a question or suggestion, ask it in the language the user is talking in. I want to ensure that our communication remains in the same language as the user."""
+- Please respond in the language the user is talking to you in, If you have a question or suggestion, \
+ask it in the language the user is talking in. \
+I want to ensure that our communication remains in the same language as the user."""
 
 MCP_TOOL_PROMPT = """
 ## Tool Parameter Notice
@@ -344,14 +327,13 @@ When using MCP tools, `user_id` and `project_id` parameters are automatically in
 You MUST NOT specify these parameters in tool calls - they will be overwritten by the system for security."""
 
 WEB_SEARCH_PROMPT = """
-## Web Search Guidelines (MANDATORY)
-When performing web searches, you MUST follow these rules strictly:
-1. Search with max_results of 10 to get diverse sources
-2. You MUST call fetch_content on AT LEAST 3 different URLs - this is a hard requirement, not optional
-3. If a website returns an error (403, timeout, etc.), try another URL until you have successfully fetched 3+ pages
-4. Do NOT stop after fetching only 1-2 websites - always continue until you have 3+ successful fetches
-5. Synthesize information from all fetched sources before responding
-6. Always cite the sources you used with their URLs"""
+## Web Search Guidelines
+Use the WebSearch tool to find current information that is not in the user's documents:
+1. Keep queries concise (under 200 characters) for the best results
+2. Synthesize information from multiple results before responding
+3. Always cite the sources you used with their URLs
+4. Note the publication date of a source when available
+5. If the results are insufficient, say so rather than guessing"""
 
 
 def fetch_voice_system_prompt() -> str | None:
@@ -414,44 +396,20 @@ async def execute_tool(tool_use: dict, context: dict) -> dict:
             "content": [{"text": json.dumps(builtin_result)}],
         }
 
-    # Try DuckDuckGo tool
-    if duckduckgo_client and tool_name in duckduckgo_tool_names:
-        try:
-            result = duckduckgo_client.call_tool_sync(name=tool_name, arguments=tool_input, tool_use_id=tool_use_id)
-            logger.info(f"DuckDuckGo result type: {type(result)}")
-
-            content = []
-            if hasattr(result, "content"):
-                for block in result.content:
-                    if hasattr(block, "text"):
-                        content.append({"text": block.text})
-                    else:
-                        content.append({"text": str(block)})
-            else:
-                content.append({"text": str(result)})
-
-            return {
-                "toolUseId": tool_use_id,
-                "status": "success",
-                "content": content,
-            }
-        except Exception as e:
-            logger.exception(f"DuckDuckGo tool execution failed: {tool_name}")
-            return {
-                "toolUseId": tool_use_id,
-                "status": "error",
-                "content": [{"text": f"Tool execution failed: {str(e)}"}],
-            }
-
     # Try MCP tool
     if mcp_client:
-        # Inject user_id and project_id for MCP tools
-        if context.get("user_id"):
-            tool_input["user_id"] = context["user_id"]
-        if context.get("project_id"):
-            tool_input["project_id"] = context["project_id"]
+        # Inject user_id and project_id only for tools that accept them
+        # (e.g. document search/qa). Built-in tools like WebSearch are skipped.
+        if tool_name in mcp_injectable_names:
+            if context.get("user_id"):
+                tool_input["user_id"] = context["user_id"]
+            if context.get("project_id"):
+                tool_input["project_id"] = context["project_id"]
 
-        logger.info(f"Calling MCP tool: {tool_name} with injected params: user_id={context.get('user_id')}, project_id={context.get('project_id')}")
+        logger.info(
+            f"Calling MCP tool: {tool_name} with injected params: "
+            f"user_id={context.get('user_id')}, project_id={context.get('project_id')}"
+        )
         logger.info(f"Full tool_input: {tool_input}")
 
         try:
@@ -532,7 +490,9 @@ async def ws_endpoint(websocket: WebSocket):
         model_type=model_type,
     )
     if transcript_saver.enabled:
-        logger.info(f"Transcript saving enabled for session {config_msg.get('session_id')} ({transcript_saver.agent_id})")
+        logger.info(
+            f"Transcript saving enabled for session {config_msg.get('session_id')} ({transcript_saver.agent_id})"
+        )
     api_key = config_msg.get("api_key")
     voice = config_msg.get("voice", "tiffany")
 
@@ -550,14 +510,16 @@ async def ws_endpoint(websocket: WebSocket):
 
     user_timezone = config_msg.get("browser_time_zone", "UTC")
 
-    # Combine builtin tools with DuckDuckGo and MCP tools
-    all_tools = get_tools() + duckduckgo_tools + mcp_tools
+    # Combine builtin tools with gateway MCP tools (search, qa, WebSearch)
+    all_tools = get_tools() + mcp_tools
     has_mcp = len(mcp_tools) > 0
 
     try:
         custom_prompt = config_msg.get("system_prompt")
-        has_ddg = len(duckduckgo_tools) > 0
-        system_prompt = custom_prompt or build_system_prompt(user_timezone, has_mcp_tools=has_mcp, has_web_search=has_ddg)
+        has_web_search = any(t["name"] == "WebSearch" for t in mcp_tools)
+        system_prompt = custom_prompt or build_system_prompt(
+            user_timezone, has_mcp_tools=has_mcp, has_web_search=has_web_search
+        )
         logger.info(f"Starting model with {len(all_tools)} tools: {[t['name'] for t in all_tools]}")
         await model.start(system_prompt=system_prompt, tools=all_tools)
         logger.info("voice model started successfully")
@@ -668,7 +630,8 @@ async def ws_endpoint(websocket: WebSocket):
                                 "sample_rate": sample_rate,
                             })
                 elif isinstance(event, BidiTranscriptStreamEvent):
-                    logger.info(f"Transcript: role={event.role}, is_final={event.is_final}, text={event.text[:50] if event.text else '(empty)'}...")
+                    transcript_text = event.text[:50] if event.text else "(empty)"
+                    logger.info(f"Transcript: role={event.role}, is_final={event.is_final}, text={transcript_text}...")
                     await websocket.send_json(
                         {
                             "type": "transcript",
@@ -788,34 +751,28 @@ async def ws_endpoint(websocket: WebSocket):
             logger.info(f"WebSocket disconnected after {event_count} events")
         except BidiModelTimeoutError:
             logger.info("Voice chat session timed out due to inactivity")
-            try:
+            with suppress(Exception):
                 await websocket.send_json({
                     "type": "timeout",
                     "reason": "Session timed out due to inactivity",
                 })
-            except Exception:
-                pass
         except ConnectionClosedError as e:
             logger.warning(f"Model WebSocket closed unexpectedly after {event_count} events: {e}")
-            try:
+            with suppress(Exception):
                 await websocket.send_json({
                     "type": "error",
                     "message": f"Model connection closed: {e}",
                 })
-            except Exception:
-                pass
         except Exception as e:
             error_str = str(e)
             # Nova Sonic input timeout (user silent too long)
             if "Timed out waiting for input events" in error_str:
                 logger.info(f"Model input timeout after {event_count} events: {e}")
-                try:
+                with suppress(Exception):
                     await websocket.send_json({
                         "type": "timeout",
                         "reason": "Session timed out due to inactivity",
                     })
-                except Exception:
-                    pass
             # Handle "websocket.send after close" errors gracefully
             elif isinstance(e, RuntimeError) and ("websocket" in error_str.lower() or "closed" in error_str.lower()):
                 logger.info(f"WebSocket closed while sending (after {event_count} events): {e}")

--- a/packages/agents/bidi-agent/pyproject.toml
+++ b/packages/agents/bidi-agent/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "pytz>=2025.2",
     "httpx>=0.28.1",
     "mcp>=1.26.0",
-    "duckduckgo-mcp-server>=0.1.1",
 ]
 
 [build-system]

--- a/packages/agents/idp-agent/agents/idp_agent.py
+++ b/packages/agents/idp-agent/agents/idp_agent.py
@@ -2,12 +2,10 @@ from contextlib import ExitStack, contextmanager
 
 import boto3
 from botocore.config import Config as BotocoreConfig
-from mcp import StdioServerParameters, stdio_client
 from strands import Agent, AgentSkills
 from strands.hooks.registry import HookProvider
 from strands.models import BedrockModel
 from strands.session import S3SessionManager
-from strands.tools.mcp.mcp_client import MCPClient
 from strands_tools import calculator, current_time, file_read, generate_image, http_request, shell, use_llm
 from strands_tools.code_interpreter import AgentCoreCodeInterpreter
 
@@ -59,18 +57,6 @@ def get_mcp_client():
     )
 
 
-def get_duckduckgo_mcp_client():
-    """Get MCP client for DuckDuckGo search server."""
-
-    return MCPClient(
-        lambda: stdio_client(
-            StdioServerParameters(
-                command="duckduckgo-mcp-server",
-            )
-        )
-    )
-
-
 @contextmanager
 def get_agent(
     session_id: str,
@@ -91,7 +77,6 @@ def get_agent(
     """
     session_manager = get_session_manager(session_id, user_id=user_id, project_id=project_id)
     mcp_client = get_mcp_client()
-    duckduckgo_client = get_duckduckgo_mcp_client()
 
     config = get_config()
 
@@ -153,10 +138,8 @@ def get_agent(
         )
 
     with ExitStack() as stack:
-        if duckduckgo_client:
-            stack.enter_context(duckduckgo_client)
-            tools.extend(duckduckgo_client.list_tools_sync())
-
+        # Web search is provided by the AgentCore Gateway WebSearch target,
+        # discovered together with the other gateway tools below.
         if mcp_client:
             stack.enter_context(mcp_client)
             tools.extend(mcp_client.list_tools_sync())

--- a/packages/agents/idp-agent/pyproject.toml
+++ b/packages/agents/idp-agent/pyproject.toml
@@ -7,7 +7,6 @@ readme = "README.md"
 dependencies = [
   "aws-opentelemetry-distro>=0.15.0",
   "bedrock-agentcore>=1.6.0",
-  "duckduckgo-mcp-server>=0.1.1",
   "fastapi>=0.132.0",
   "boto3>=1.42.55",
   "mcp>=1.26.0",

--- a/packages/agents/research-agent/agents/supervisor.py
+++ b/packages/agents/research-agent/agents/supervisor.py
@@ -60,6 +60,7 @@ def get_supervisor_agent(
         overview_tools = []
         summarize_tools = []
         image_tools = []
+        websearch_tools = []
 
         if mcp_client:
             stack.enter_context(mcp_client)
@@ -77,6 +78,9 @@ def get_supervisor_agent(
                 filter_tools_by_keyword(mcp_tools, "image"),
                 user_id, project_id
             )
+            # WebSearch is a built-in gateway tool without user_id/project_id,
+            # so it is passed through without auto-injection wrapping.
+            websearch_tools = filter_tools_by_keyword(mcp_tools, "WebSearch")
 
         plan_tool = create_plan_tool(
             session_id, project_id, user_id, mcp_tools=overview_tools
@@ -84,7 +88,7 @@ def get_supervisor_agent(
         research_tool = create_research_tool(
             session_id, project_id, user_id, mcp_tools=summarize_tools
         )
-        websearch_tool = create_websearch_tool()
+        websearch_tool = create_websearch_tool(mcp_tools=websearch_tools)
         write_tool = create_write_tool(session_id, project_id, user_id)
         pptx_tool = create_pptx_tool(
             session_id, project_id, user_id, mcp_tools=image_tools

--- a/packages/agents/research-agent/agents/websearch.py
+++ b/packages/agents/research-agent/agents/websearch.py
@@ -1,37 +1,27 @@
-from mcp import StdioServerParameters, stdio_client
 from strands import Agent, tool
 from strands.models import BedrockModel
-from strands.tools.mcp import MCPClient
 
 from agents.constants import RESEARCH_MODEL_ID
 from config import get_config
 
-
-def get_ddg_mcp_client() -> MCPClient:
-    """Get DuckDuckGo MCP client for web search."""
-    return MCPClient(
-        lambda: stdio_client(
-            StdioServerParameters(command="duckduckgo-mcp-server", args=[])
-        )
-    )
-
-
 WEBSEARCH_SYSTEM_PROMPT = """You are a web search agent specialized in finding supplementary information from the web.
 
 Your role is to:
-1. Search the web using DuckDuckGo to find relevant information
+1. Search the web using the WebSearch tool to find relevant information
 2. Provide supplementary context and background information
 3. Clearly mark all information as web-sourced
 
 ## Guidelines
 - Focus on finding definitions, background context, and supplementary information
-- Always cite web sources
+- Keep queries concise (under 200 characters) for the best results
+- Always cite web sources with their URLs
+- Note the publication date of a source when available
 - Present information concisely
 - Call tools immediately without asking for additional information
 """
 
 
-async def _run_websearch_async(query: str) -> str:
+async def _run_websearch_async(query: str, mcp_tools: list) -> str:
     """Run websearch agent asynchronously."""
     config = get_config()
 
@@ -40,22 +30,23 @@ async def _run_websearch_async(query: str) -> str:
         region_name=config.aws_region,
     )
 
-    ddg_client = get_ddg_mcp_client()
-    with ddg_client:
-        ddg_tools = ddg_client.list_tools_sync()
+    agent = Agent(
+        model=bedrock_model,
+        system_prompt=WEBSEARCH_SYSTEM_PROMPT,
+        tools=mcp_tools,
+    )
 
-        agent = Agent(
-            model=bedrock_model,
-            system_prompt=WEBSEARCH_SYSTEM_PROMPT,
-            tools=ddg_tools,
-        )
-
-        result = await agent.invoke_async(query)
-        return str(result)
+    result = await agent.invoke_async(query)
+    return str(result)
 
 
-def create_websearch_tool():
-    """Create a websearch agent tool."""
+def create_websearch_tool(mcp_tools: list | None = None):
+    """Create a websearch agent tool backed by the AgentCore WebSearch tool.
+
+    Args:
+        mcp_tools: Gateway WebSearch tool(s) shared from the supervisor's MCP client.
+    """
+    tools = mcp_tools or []
 
     @tool
     async def websearch_agent(query: str) -> str:
@@ -70,6 +61,8 @@ def create_websearch_tool():
         Returns:
             Web search results
         """
-        return await _run_websearch_async(query)
+        if not tools:
+            return "Web search is not available: the WebSearch tool is not configured."
+        return await _run_websearch_async(query, tools)
 
     return websearch_agent

--- a/packages/agents/research-agent/pyproject.toml
+++ b/packages/agents/research-agent/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "aws-opentelemetry-distro>=0.15.0",
     "bedrock-agentcore>=1.3.2",
     "boto3>=1.42.55",
-    "duckduckgo-mcp-server>=0.1.1",
     "nanoid>=2.0.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.13.1",

--- a/packages/frontend/src/components/TemplateUploadModal.tsx
+++ b/packages/frontend/src/components/TemplateUploadModal.tsx
@@ -88,7 +88,11 @@ export default function TemplateUploadModal({
 
   const handleUpload = useCallback(async () => {
     if (!file || !name.trim()) return;
-    await onUpload({ name: name.trim(), description: description.trim(), file });
+    await onUpload({
+      name: name.trim(),
+      description: description.trim(),
+      file,
+    });
     resetForm();
   }, [file, name, description, onUpload, resetForm]);
 
@@ -189,7 +193,10 @@ export default function TemplateUploadModal({
                 >
                   {isDragging
                     ? t('documents.dropHere', 'Drop files here')
-                    : t('documents.dragDrop', 'Drag & drop files or click to browse')}
+                    : t(
+                        'documents.dragDrop',
+                        'Drag & drop files or click to browse',
+                      )}
                 </p>
                 <p className="text-xs text-[#64748b] text-center">
                   {t('templates.supportedFormats')}

--- a/packages/infra/src/stacks/mcp-stack.ts
+++ b/packages/infra/src/stacks/mcp-stack.ts
@@ -1,6 +1,8 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as cr from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import {
   SearchMcp,
@@ -74,6 +76,72 @@ export class McpStack extends Stack {
     });
     this.qaMcp.function.grantInvoke(this.gateway.role);
     qaTarget.node.addDependency(this.gateway.role);
+
+    // Web Search built-in connector target. The AgentCore Web Search connector
+    // is not yet supported by the CDK L2/L1 target APIs, so it is created via a
+    // control-plane call. The Gateway IAM role invokes the managed tool.
+    const webSearchToolArn = `arn:aws:bedrock-agentcore:${this.region}:aws:tool/web-search.v1`;
+    this.gateway.role.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'InvokeWebSearch',
+        actions: ['bedrock-agentcore:InvokeWebSearch'],
+        resources: [webSearchToolArn],
+      }),
+    );
+
+    const webSearchTarget = new cr.AwsCustomResource(this, 'WebSearchTarget', {
+      onCreate: {
+        service: 'bedrock-agentcore-control',
+        action: 'createGatewayTarget',
+        parameters: {
+          gatewayIdentifier: this.gateway.gatewayId,
+          name: 'web-search',
+          description:
+            'Web search tool: search the public web for current information and return ranked results with source URLs, titles, and publication dates.',
+          targetConfiguration: {
+            mcp: {
+              connector: {
+                source: { connectorId: 'web-search' },
+                configurations: [{ name: 'WebSearch', parameterValues: {} }],
+              },
+            },
+          },
+          credentialProviderConfigurations: [
+            { credentialProviderType: 'GATEWAY_IAM_ROLE' },
+          ],
+        },
+        physicalResourceId: cr.PhysicalResourceId.fromResponse('targetId'),
+      },
+      onDelete: {
+        service: 'bedrock-agentcore-control',
+        action: 'deleteGatewayTarget',
+        parameters: {
+          gatewayIdentifier: this.gateway.gatewayId,
+          targetId: new cr.PhysicalResourceIdReference(),
+        },
+      },
+      // The web-search connector is only known to recent AWS SDK versions.
+      // This project defaults installLatestAwsSdk to false, so force it on for
+      // this resource; otherwise the connector config is dropped and the target
+      // fails validation.
+      installLatestAwsSdk: true,
+      policy: cr.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: [
+            'bedrock-agentcore:CreateGatewayTarget',
+            'bedrock-agentcore:DeleteGatewayTarget',
+            'bedrock-agentcore:GetGatewayTarget',
+            'bedrock-agentcore:ListGatewayTargets',
+            // createGatewayTarget/deleteGatewayTarget internally reconcile the
+            // gateway's target set, which requires SynchronizeGatewayTargets.
+            'bedrock-agentcore:SynchronizeGatewayTargets',
+          ],
+          resources: [this.gateway.gatewayArn, `${this.gateway.gatewayArn}/*`],
+        }),
+      ]),
+    });
+    webSearchTarget.node.addDependency(this.gateway.role);
+    webSearchTarget.node.addDependency(this.gateway);
 
     // ImageMcp is optional - enable with context: enableImageMcp=true in cdk.json
     if (this.node.tryGetContext('enableImageMcp')) {

--- a/uv.lock
+++ b/uv.lock
@@ -847,21 +847,6 @@ wheels = [
 ]
 
 [[package]]
-name = "duckduckgo-mcp-server"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "httpcore" },
-    { name = "httpx" },
-    { name = "mcp", extra = ["cli"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/a2/d439a55f0c3102902068826ca68825f7921afad639af1ff8649dc3416760/duckduckgo_mcp_server-0.4.0.tar.gz", hash = "sha256:4338b05321bcc8809aadd3b1db808e42ebe7736c5dfa74981770e7d8acf07455", size = 77611, upload-time = "2026-05-08T19:22:52.158Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/94/24520ce6721a426bc9ec6978d59238c7b339282e9ab9686b64a1dedb16cf/duckduckgo_mcp_server-0.4.0-py3-none-any.whl", hash = "sha256:6183b27379ead2d9dac50a7580cc249311b619e7dec9a27bf9ec1bef3dd385dd", size = 21014, upload-time = "2026-05-08T19:22:51.003Z" },
-]
-
-[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1361,7 +1346,6 @@ source = { editable = "packages/agents/bidi-agent" }
 dependencies = [
     { name = "asyncio" },
     { name = "boto3" },
-    { name = "duckduckgo-mcp-server" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "mcp" },
@@ -1375,7 +1359,6 @@ dependencies = [
 requires-dist = [
     { name = "asyncio", specifier = ">=4.0.0" },
     { name = "boto3", specifier = ">=1.42.55" },
-    { name = "duckduckgo-mcp-server", specifier = ">=0.1.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.132.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", specifier = ">=1.26.0" },
@@ -1393,7 +1376,6 @@ dependencies = [
     { name = "aws-opentelemetry-distro" },
     { name = "bedrock-agentcore" },
     { name = "boto3" },
-    { name = "duckduckgo-mcp-server" },
     { name = "fastapi" },
     { name = "mcp" },
     { name = "nanoid" },
@@ -1414,7 +1396,6 @@ requires-dist = [
     { name = "aws-opentelemetry-distro", specifier = ">=0.15.0" },
     { name = "bedrock-agentcore", specifier = ">=1.6.0" },
     { name = "boto3", specifier = ">=1.42.55" },
-    { name = "duckduckgo-mcp-server", specifier = ">=0.1.1" },
     { name = "fastapi", specifier = ">=0.132.0" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -1438,7 +1419,6 @@ dependencies = [
     { name = "aws-opentelemetry-distro" },
     { name = "bedrock-agentcore" },
     { name = "boto3" },
-    { name = "duckduckgo-mcp-server" },
     { name = "nanoid" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1451,7 +1431,6 @@ requires-dist = [
     { name = "aws-opentelemetry-distro", specifier = ">=0.15.0" },
     { name = "bedrock-agentcore", specifier = ">=1.3.2" },
     { name = "boto3", specifier = ">=1.42.55" },
-    { name = "duckduckgo-mcp-server", specifier = ">=0.1.1" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
@@ -1726,12 +1705,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
-]
-
-[package.optional-dependencies]
-cli = [
-    { name = "python-dotenv" },
-    { name = "typer" },
 ]
 
 [[package]]


### PR DESCRIPTION
  - McpStack에 web-search connector target 추가 (AwsCustomResource, installLatestAwsSdk: true, InvokeWebSearch/SynchronizeGatewayTargets 권한)
  - idp/bidi/research 3개 에이전트에서 DuckDuckGo MCP 제거, gateway WebSearch 도구로 교체
  - bidi-agent: user_id/project_id 자동 주입을 스키마 보유 도구로 한정 (mcp_injectable_names)
  - research-agent: websearch 서브에이전트를 gateway WebSearch 기반으로 전환
  - 3개 에이전트 pyproject.toml 및 uv.lock에서 duckduckgo-mcp-server 의존성 제거
  - bidi-agent 기존 lint 정리 (E402/E501/SIM105)
  - TemplateUploadModal.tsx prettier 포맷 수정