### PR TITLE
feat(backend): add template DynamoDB read layer

### DIFF
--- a/packages/backend/app/ddb/client.py
+++ b/packages/backend/app/ddb/client.py
@@ -36,6 +36,10 @@ def generate_project_id() -> str:
     return f"proj_{generate_nanoid()}"
 
 
+def generate_template_id() -> str:
+    return f"tpl_{generate_nanoid()}"
+
+
 def batch_delete_items(items: list[DdbKey]) -> None:
     """Batch delete items from DynamoDB."""
     table = get_table()

--- a/packages/backend/app/ddb/models.py
+++ b/packages/backend/app/ddb/models.py
@@ -108,6 +108,24 @@ class SegmentAnalysis(BaseModel):
     ai_analysis: list[AIAnalysis] = []
 
 
+class TemplateData(BaseModel):
+    template_id: str
+    name: str
+    description: str
+    file_type: str
+    s3_key: str
+    thumbnail_url: str | None = None
+    analysis_status: str
+    generated_prompt: str | None = None
+    created_by: str | None = None
+
+
+class Template(BaseModel):
+    data: TemplateData
+    created_at: str
+    updated_at: str
+
+
 class ArtifactData(BaseModel):
     user_id: str
     project_id: str

--- a/packages/backend/app/ddb/templates.py
+++ b/packages/backend/app/ddb/templates.py
@@ -1,0 +1,26 @@
+from boto3.dynamodb.conditions import Key
+
+from app.ddb.client import get_table
+from app.ddb.models import DdbKey, Template
+
+
+def make_template_key(template_id: str) -> DdbKey:
+    return {"PK": f"TPL#{template_id}", "SK": "META"}
+
+
+def query_templates() -> list[Template]:
+    """Query all templates using GSI1 (global, newest first)."""
+    table = get_table()
+    response = table.query(
+        IndexName="GSI1",
+        KeyConditionExpression=Key("GSI1PK").eq("TEMPLATES"),
+        ScanIndexForward=False,
+    )
+    return [Template(**item) for item in response.get("Items", [])]
+
+
+def get_template_item(template_id: str) -> Template | None:
+    table = get_table()
+    response = table.get_item(Key=make_template_key(template_id))
+    item = response.get("Item")
+    return Template(**item) if item else None


### PR DESCRIPTION
- Add Template/TemplateData models mirroring the Project entity
- Add generate_template_id() producing tpl_{nanoid} ids
- Add templates.py with make_template_key, get_template_item, and query_templates (global list via GSI1, newest first)

Templates are global (GSI1PK=TEMPLATES), following the Project key pattern. Read paths only; write/update/delete and router to follow.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
