### PR TITLE
feat: template upload with presigned URL

### DIFF
--- a/packages/backend/app/ddb/__init__.py
+++ b/packages/backend/app/ddb/__init__.py
@@ -1,4 +1,10 @@
-from app.ddb.client import batch_delete_items, generate_project_id, get_table, now_iso
+from app.ddb.client import (
+    batch_delete_items,
+    generate_project_id,
+    generate_template_id,
+    get_table,
+    now_iso,
+)
 from app.ddb.documents import (
     delete_document_item,
     get_document_item,
@@ -6,7 +12,14 @@ from app.ddb.documents import (
     query_documents,
     update_document_data,
 )
-from app.ddb.models import Document, DocumentData, Project, ProjectData
+from app.ddb.models import (
+    Document,
+    DocumentData,
+    Project,
+    ProjectData,
+    Template,
+    TemplateData,
+)
 from app.ddb.projects import (
     get_project_item,
     mark_project_updated,
@@ -14,6 +27,11 @@ from app.ddb.projects import (
     query_all_project_items,
     query_projects,
     update_project_data,
+)
+from app.ddb.templates import (
+    get_template_item,
+    put_template_item,
+    query_templates,
 )
 from app.ddb.workflows import (
     delete_workflow_item,
@@ -28,11 +46,14 @@ __all__ = [
     "now_iso",
     "batch_delete_items",
     "generate_project_id",
+    "generate_template_id",
     # models
     "Project",
     "ProjectData",
     "Document",
     "DocumentData",
+    "Template",
+    "TemplateData",
     # projects
     "query_projects",
     "get_project_item",
@@ -46,6 +67,10 @@ __all__ = [
     "update_document_data",
     "query_documents",
     "delete_document_item",
+    # templates
+    "query_templates",
+    "get_template_item",
+    "put_template_item",
     # workflows
     "get_workflow_item",
     "query_workflows",

--- a/packages/backend/app/ddb/models.py
+++ b/packages/backend/app/ddb/models.py
@@ -115,7 +115,7 @@ class TemplateData(BaseModel):
     file_type: str
     s3_key: str
     thumbnail_url: str | None = None
-    analysis_status: str
+    status: str
     generated_prompt: str | None = None
     created_by: str | None = None
 

--- a/packages/backend/app/ddb/templates.py
+++ b/packages/backend/app/ddb/templates.py
@@ -1,11 +1,25 @@
 from boto3.dynamodb.conditions import Key
 
-from app.ddb.client import get_table
-from app.ddb.models import DdbKey, Template
+from app.ddb.client import get_table, now_iso
+from app.ddb.models import DdbKey, Template, TemplateData
 
 
 def make_template_key(template_id: str) -> DdbKey:
     return {"PK": f"TPL#{template_id}", "SK": "META"}
+
+
+def put_template_item(template_id: str, data: TemplateData) -> None:
+    table = get_table()
+    now = now_iso()
+    item = {
+        **make_template_key(template_id),
+        "GSI1PK": "TEMPLATES",
+        "GSI1SK": now,
+        "data": data.model_dump(),
+        "created_at": now,
+        "updated_at": now,
+    }
+    table.put_item(Item=item)
 
 
 def query_templates() -> list[Template]:

--- a/packages/backend/app/main.py
+++ b/packages/backend/app/main.py
@@ -11,6 +11,7 @@ from app.routers import (
     projects,
     prompts,
     sagemaker,
+    templates,
     workflows,
 )
 
@@ -26,6 +27,7 @@ app = FastAPI(
         {"name": "prompts", "description": "프롬프트 관리"},
         {"name": "sagemaker", "description": "SageMaker 엔드포인트 관리"},
         {"name": "graph", "description": "지식 그래프 관리"},
+        {"name": "templates", "description": "템플릿 관리"},
     ]
 )
 
@@ -46,4 +48,5 @@ app.include_router(health.router)
 app.include_router(projects.router)
 app.include_router(prompts.router)
 app.include_router(sagemaker.router)
+app.include_router(templates.router)
 app.include_router(workflows.router)

--- a/packages/backend/app/routers/templates.py
+++ b/packages/backend/app/routers/templates.py
@@ -1,0 +1,100 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.config import get_config
+from app.ddb import (
+    Template,
+    TemplateData,
+    generate_template_id,
+    put_template_item,
+    query_templates,
+)
+from app.s3 import get_s3_client
+
+router = APIRouter(prefix="/templates", tags=["templates"])
+
+ALLOWED_EXTENSIONS = {"pptx", "ppt"}
+
+
+class TemplateUploadRequest(BaseModel):
+    name: str
+    description: str = ""
+    file_name: str
+    content_type: str
+    file_size: int
+
+
+class TemplateUploadResponse(BaseModel):
+    template_id: str
+    upload_url: str
+    file_name: str
+
+
+class TemplateResponse(BaseModel):
+    template_id: str
+    name: str
+    description: str
+    file_type: str
+    thumbnail_url: str | None = None
+    status: str
+    created_at: str
+
+    @staticmethod
+    def from_template(template: Template) -> "TemplateResponse":
+        return TemplateResponse(
+            template_id=template.data.template_id,
+            name=template.data.name,
+            description=template.data.description,
+            file_type=template.data.file_type,
+            thumbnail_url=template.data.thumbnail_url,
+            status=template.data.status,
+            created_at=template.created_at,
+        )
+
+
+@router.get("")
+def list_templates() -> list[TemplateResponse]:
+    """List all templates (global, newest first)."""
+    templates = query_templates()
+    return [TemplateResponse.from_template(template) for template in templates]
+
+
+@router.post("")
+def create_template_upload(request: TemplateUploadRequest) -> TemplateUploadResponse:
+    """Create a template record and return a presigned URL for upload."""
+    config = get_config()
+    s3 = get_s3_client()
+
+    ext = request.file_name.rsplit(".", 1)[-1].lower() if "." in request.file_name else ""
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Only PPTX/PPT files are allowed")
+
+    template_id = generate_template_id()
+    s3_key = f"templates/{template_id}/{template_id}.{ext}"
+
+    data = TemplateData(
+        template_id=template_id,
+        name=request.name,
+        description=request.description,
+        file_type=ext,
+        s3_key=s3_key,
+        status="uploading",
+    )
+    put_template_item(template_id, data)
+
+    # Generate presigned URL for upload (valid for 1 hour)
+    upload_url = s3.generate_presigned_url(
+        "put_object",
+        Params={
+            "Bucket": config.document_storage_bucket_name,
+            "Key": s3_key,
+            "ContentType": request.content_type,
+        },
+        ExpiresIn=3600,
+    )
+
+    return TemplateUploadResponse(
+        template_id=template_id,
+        upload_url=upload_url,
+        file_name=request.file_name,
+    )

--- a/packages/frontend/src/components/TemplateCard.tsx
+++ b/packages/frontend/src/components/TemplateCard.tsx
@@ -6,7 +6,8 @@ export interface Template {
   name: string;
   description: string;
   file_type: string;
-  thumbnail_url: string;
+  thumbnail_url?: string | null;
+  status?: string;
   created_at: string;
 }
 
@@ -39,12 +40,18 @@ function TemplateCard({ template, onClick }: TemplateCardProps) {
     >
       {/* Thumbnail */}
       <div className="relative aspect-[4/3] overflow-hidden bg-slate-100 dark:bg-slate-800">
-        <img
-          src={template.thumbnail_url}
-          alt={template.name}
-          loading="lazy"
-          className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
-        />
+        {template.thumbnail_url ? (
+          <img
+            src={template.thumbnail_url}
+            alt={template.name}
+            loading="lazy"
+            className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 dark:from-slate-800 dark:to-slate-900">
+            <FileText className="w-12 h-12 text-slate-300 dark:text-slate-600" />
+          </div>
+        )}
         <span
           className={`absolute top-3 left-3 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white rounded-md ${
             FILE_TYPE_BADGE[template.file_type] ?? 'bg-slate-500/90'

--- a/packages/frontend/src/hooks/useTemplates.ts
+++ b/packages/frontend/src/hooks/useTemplates.ts
@@ -1,0 +1,87 @@
+import { useState, useCallback } from 'react';
+import type { Template } from '../components/TemplateCard';
+import type { TemplateUploadResponse } from '../types/project';
+import type { TemplateUploadData } from '../components/TemplateUploadModal';
+
+const EXT_MIME: Record<string, string> = {
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  ppt: 'application/vnd.ms-powerpoint',
+};
+
+const getMimeType = (file: File): string => {
+  if (file.type) return file.type;
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  return EXT_MIME[ext] ?? 'application/octet-stream';
+};
+
+interface UseTemplatesOptions {
+  fetchApi: <T>(url: string, init?: RequestInit) => Promise<T>;
+}
+
+export function useTemplates({ fetchApi }: UseTemplatesOptions) {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const loadTemplates = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchApi<Template[]>('templates');
+      setTemplates(data);
+    } catch (error) {
+      console.error('Failed to load templates:', error);
+      setTemplates([]);
+    }
+    setLoading(false);
+  }, [fetchApi]);
+
+  const uploadTemplate = useCallback(
+    async (data: TemplateUploadData) => {
+      setUploading(true);
+      try {
+        const contentType = getMimeType(data.file);
+
+        // 1) 백엔드에 레코드 생성 + presigned PUT URL 발급 요청
+        const uploadInfo = await fetchApi<TemplateUploadResponse>('templates', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: data.name,
+            description: data.description,
+            file_name: data.file.name,
+            content_type: contentType,
+            file_size: data.file.size,
+          }),
+        });
+
+        // 2) presigned URL로 S3에 파일 직접 업로드
+        //    업로드 완료 후 상태 갱신은 S3 이벤트 트리거(Lambda)에서 처리한다.
+        const uploadResponse = await fetch(uploadInfo.upload_url, {
+          method: 'PUT',
+          body: data.file,
+          headers: { 'Content-Type': contentType },
+        });
+
+        if (!uploadResponse.ok) {
+          throw new Error(`Failed to upload ${data.file.name} to S3`);
+        }
+
+        await loadTemplates();
+      } catch (error) {
+        console.error('Failed to upload template:', error);
+        throw error;
+      } finally {
+        setUploading(false);
+      }
+    },
+    [fetchApi, loadTemplates],
+  );
+
+  return {
+    templates,
+    loading,
+    uploading,
+    loadTemplates,
+    uploadTemplate,
+  };
+}

--- a/packages/frontend/src/routes/templates.tsx
+++ b/packages/frontend/src/routes/templates.tsx
@@ -54,7 +54,7 @@ function TemplatesPage() {
       </header>
 
       {/* Filter Bar */}
-      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
         <div className="relative flex-1 max-w-md">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
           <input
@@ -65,6 +65,13 @@ function TemplatesPage() {
             className="w-full pl-10 pr-4 py-2.5 text-sm bg-transparent dark:bg-white/[0.06] border border-black/10 dark:border-white/[0.12] rounded-xl outline-none focus:border-blue-500 dark:focus:border-blue-400 focus:ring-2 focus:ring-blue-500/20 transition-all text-slate-700 dark:text-slate-200"
           />
         </div>
+        <button
+          onClick={() => setShowUploadModal(true)}
+          className="flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-indigo-600 dark:hover:bg-indigo-500 rounded-xl transition-colors shrink-0"
+        >
+          <Plus className="w-4 h-4" />
+          {t('templates.newTemplate')}
+        </button>
       </div>
 
       {/* Content */}
@@ -75,32 +82,12 @@ function TemplatesPage() {
             <h3 className="text-lg font-medium text-slate-700 dark:text-slate-300 mb-2">
               {t('templates.noTemplates')}
             </h3>
-            <p className="text-sm text-slate-500 dark:text-slate-400 text-center max-w-md mb-6">
+            <p className="text-sm text-slate-500 dark:text-slate-400 text-center max-w-md">
               {t('templates.noTemplatesDescription')}
             </p>
-            <button
-              onClick={() => setShowUploadModal(true)}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-indigo-600 dark:hover:bg-indigo-500 rounded-lg transition-colors"
-            >
-              <Plus className="w-4 h-4" />
-              {t('templates.newTemplate')}
-            </button>
           </div>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-            {/* New Template Card */}
-            <button
-              onClick={() => setShowUploadModal(true)}
-              className="template-card-new group flex flex-col items-center justify-center gap-3 aspect-[4/3] rounded-2xl border-2 border-dashed border-black/15 dark:border-white/15 text-slate-400 hover:border-blue-500/50 hover:text-blue-500 transition-colors"
-            >
-              <div className="w-12 h-12 rounded-full flex items-center justify-center bg-black/5 dark:bg-white/5 group-hover:bg-blue-500/10 transition-colors">
-                <Plus className="w-6 h-6" />
-              </div>
-              <span className="text-sm font-medium">
-                {t('templates.newTemplate')}
-              </span>
-            </button>
-
             {filteredTemplates.map((template) => (
               <TemplateCard key={template.template_id} template={template} />
             ))}

--- a/packages/frontend/src/routes/templates.tsx
+++ b/packages/frontend/src/routes/templates.tsx
@@ -1,90 +1,37 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Search, FileText, Plus } from 'lucide-react';
-import TemplateCard, { Template } from '../components/TemplateCard';
+import TemplateCard from '../components/TemplateCard';
 import TemplateUploadModal, {
   TemplateUploadData,
 } from '../components/TemplateUploadModal';
+import { useAwsClient } from '../hooks/useAwsClient';
+import { useTemplates } from '../hooks/useTemplates';
 
 export const Route = createFileRoute('/templates')({
   component: TemplatesPage,
 });
 
-// TODO: Replace with API data.
-const MOCK_TEMPLATES: Template[] = [
-  {
-    template_id: 'tpl-001',
-    name: 'Business Proposal Deck',
-    description: 'Clean 16:9 slides with title, agenda, and section dividers.',
-    file_type: 'pptx',
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?w=800&q=80',
-    created_at: '2026-06-20T09:00:00Z',
-  },
-  {
-    template_id: 'tpl-002',
-    name: 'Quarterly Report',
-    description: 'Data-heavy layout with charts, tables, and summary sections.',
-    file_type: 'pptx',
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1543286386-713bdd548da4?w=800&q=80',
-    created_at: '2026-06-18T14:30:00Z',
-  },
-  {
-    template_id: 'tpl-003',
-    name: 'Product Overview',
-    description: 'Slide layout with hero, features, and call to action.',
-    file_type: 'pptx',
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1517842645767-c639042777db?w=800&q=80',
-    created_at: '2026-06-15T11:15:00Z',
-  },
-  {
-    template_id: 'tpl-004',
-    name: 'Technical Design Deck',
-    description: 'Structured slides for architecture, APIs, and diagrams.',
-    file_type: 'pptx',
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1503676260728-1c00da094a0b?w=800&q=80',
-    created_at: '2026-06-10T08:45:00Z',
-  },
-  {
-    template_id: 'tpl-005',
-    name: 'Pitch Deck',
-    description: 'Bold visual slides for storytelling and investor pitches.',
-    file_type: 'pptx',
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1552664730-d307ca884978?w=800&q=80',
-    created_at: '2026-06-05T16:20:00Z',
-  },
-  {
-    template_id: 'tpl-006',
-    name: 'Team Update',
-    description: 'Simple structured slides for agenda, status, and next steps.',
-    file_type: 'pptx',
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1497215728101-856f4ea42174?w=800&q=80',
-    created_at: '2026-06-01T10:00:00Z',
-  },
-];
-
 function TemplatesPage() {
   const { t } = useTranslation();
+  const { fetchApi } = useAwsClient();
+  const { templates, uploading, loadTemplates, uploadTemplate } = useTemplates({
+    fetchApi,
+  });
   const [searchQuery, setSearchQuery] = useState('');
   const [showUploadModal, setShowUploadModal] = useState(false);
-  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    loadTemplates();
+  }, [loadTemplates]);
 
   const handleUpload = async (data: TemplateUploadData) => {
-    setUploading(true);
-    // TODO: Replace with API call.
-    console.log('Upload template:', data);
-    await new Promise((resolve) => setTimeout(resolve, 800));
-    setUploading(false);
+    await uploadTemplate(data);
     setShowUploadModal(false);
   };
 
-  const filteredTemplates = MOCK_TEMPLATES.filter(
+  const filteredTemplates = templates.filter(
     (template) =>
       template.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       template.description.toLowerCase().includes(searchQuery.toLowerCase()),

--- a/packages/frontend/src/types/project.ts
+++ b/packages/frontend/src/types/project.ts
@@ -207,3 +207,9 @@ export interface ArtifactsResponse {
   items: Artifact[];
   next_cursor: string | null;
 }
+
+export interface TemplateUploadResponse {
+  template_id: string;
+  upload_url: string;
+  file_name: string;
+}


### PR DESCRIPTION
## 개요
PPTX/PPT 템플릿 업로드 기능을 구현합니다. 기존 문서 업로드와 동일한 presigned URL 패턴을 사용합니다.

## 업로드 흐름
1. `POST /templates` — 템플릿 레코드 생성(`status=uploading`) + presigned S3 PUT URL 발급
2. presigned URL로 S3에 파일 직접 PUT
3. 업로드 완료 후 상태 갱신·썸네일·분석은 S3 이벤트 트리거(Lambda)에서 별도 처리

## 변경 사항

### Backend
- `routers/templates.py` (신규) — `GET /templates`, `POST /templates`(레코드 생성 + presigned URL, PPTX/PPT 확장자 검증)
- `ddb/templates.py` — `put_template_item` write 함수 추가
- `ddb/models.py` — `TemplateData.analysis_status` → `status`
- `ddb/__init__.py`, `main.py` — export 및 라우터 등록

### Frontend
- `hooks/useTemplates.ts` (신규) — 2단계 업로드(POST → S3 PUT) 및 목록 조회
- `routes/templates.tsx` — mock 데이터 제거, 실 API 연동, 업로드 버튼을 우측 상단으로 이동
- `components/TemplateCard.tsx` — 썸네일 없는 템플릿 fallback 표시
- `types/project.ts` — `TemplateUploadResponse` 타입 추가

## 후속 작업 (별도)
- S3 이벤트 → Lambda: `status` 갱신, 썸네일/`generated_prompt` 생성
- `templates/*` 대상 EventBridge 룰 추가