### PR TITLE
feat: Text2SQL structured-data pipeline with dataset catalog search

### DIFF
--- a/packages/agents/idp-agent/.skills/search/SKILL.md
+++ b/packages/agents/idp-agent/.skills/search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: searching
-description: "Search documents and knowledge graph for information. Combines hybrid search, graph traversal, and keyword graph lookup. Use when user asks questions, requests information lookup, needs explanations, summaries, or comparisons from uploaded documents. Any user question requiring information lookup. When in doubt, use this skill."
+description: "Search for information across unstructured documents (hybrid search, knowledge graph) AND structured datasets (Text2SQL over spreadsheet tables). Use when the user asks questions, requests information lookup, needs explanations, summaries, comparisons, or exact numbers/aggregations/rankings from uploaded documents or datasets. Any user question requiring information lookup. When in doubt, use this skill."
 ---
 
 # Search Skill
@@ -20,8 +20,27 @@ Follows entity connections from search results to discover additional related pa
 **`search___graph_keyword`**
 Finds pages by keyword similarity in the knowledge graph. Useful when a specific concept or term is the focus.
 
-**`search` + `fetch_content`**
-Web search via DuckDuckGo. Use only when document search is insufficient. Fetch 3+ URLs. Clearly distinguish document vs. web sources.
+**`WebSearch`**
+Managed web search (AgentCore). Returns ranked results with source URLs, titles, and publication dates. Use only when the documents and datasets are insufficient. Always cite source URLs.
+
+## Structured datasets (Text2SQL)
+
+Some projects also contain **structured datasets** (spreadsheets converted to queryable tables) alongside unstructured documents. For questions needing exact numbers, aggregation, filtering, ranking, or counting ("how many", "top N", "average", "list all X where ..."), query these instead of (or in addition to) document search.
+
+**`data___search_datasets`**
+Hybrid-search the project's dataset catalog for datasets relevant to a query (returns top matches with name + description + table_name). Call this FIRST with a description of the data you need to discover which dataset(s) can answer the question. Projects may have many datasets, so search rather than list.
+
+**`data___describe_dataset`**
+Return a dataset's reference document (columns, types, enum values, query patterns, caveats) plus its `table_name`. Call this BEFORE writing SQL — it is the source of truth for column names. Columns are normalized to snake_case (e.g. `primary_type`, `sp_atk`), so no double-quoting is needed.
+
+**`data___run_sql`**
+Run a read-only DuckDB query.
+- Single dataset: pass `dataset_uri`; the table is named `data` (`FROM data`).
+- JOIN across datasets (e.g. multiple sheets, or two related tables): pass `dataset_uris` (a list) and reference each by its `table_name` from `describe_dataset`/`search_datasets` (e.g. `FROM t_aaa a JOIN t_bbb b ON a.code = b.code`). Include EVERY dataset your SQL touches in `dataset_uris`.
+
+Workflow: `search_datasets` → `describe_dataset` (for each relevant dataset) → `run_sql`. Base the answer on query results and show the SQL used.
+
+**Joining datasets**: when a question needs data combined across tables/sheets, `describe_dataset` each one to learn its columns and `table_name`, find the shared key, then issue one `run_sql` with `dataset_uris` listing all of them. Prefer a single JOIN query over stitching separate results by hand.
 
 ## Combinations
 
@@ -30,9 +49,11 @@ Web search via DuckDuckGo. Use only when document search is insufficient. Fetch 
 - `search___graph_keyword` alone — explore a concept across documents
 - `search___summarize` + `search___graph_keyword` — comprehensive search
 - `search___summarize` → `search___graph_traverse` + `search___graph_keyword` — maximum coverage
-- Any of the above + web search — when documents are not enough
+- `data___search_datasets` → `data___describe_dataset` → `data___run_sql` — exact answers from structured data
+- Cross question (spans both): document search to identify the entity → `data___run_sql` with the name/keywords found → synthesize both
+- Any of the above + `WebSearch` — when documents and datasets are not enough
 
-Document search first. Web search last.
+Document/dataset search first. Web search last.
 
 ## Citations
 

--- a/packages/agents/idp-agent/prompts.py
+++ b/packages/agents/idp-agent/prompts.py
@@ -62,6 +62,32 @@ Execute the plan step by step:
 - Cite sources when applicable.
 - If the task produced an artifact, report the artifact reference.
 
+## Structured vs. Unstructured Data
+
+You can query two kinds of data. Choose based on the question:
+
+- **Unstructured documents** (brochures, manuals, specs) — use the document search tools.
+  Best for descriptions, features, explanations, and "how/why" questions.
+- **Structured datasets** (Parquet tables: spec sheets, catalogs, spreadsheets) — use the
+  data tools (`search_datasets`, `describe_dataset`, `run_sql`). Best for exact numbers,
+  aggregation, filtering, ranking, and counting ("how many", "top 5", "average of ...").
+
+### Using structured data tools (Text2SQL)
+1. Call `search_datasets` with a description of the data you need to find relevant datasets (projects may have many).
+2. Call `describe_dataset` to learn its columns, types, and enum values BEFORE writing SQL.
+   The reference document is the source of truth — do NOT invent column names or values.
+3. Call `run_sql` with a read-only DuckDB query. The dataset is exposed as the table `data`
+   (always query `FROM data`). Only SELECT/WITH is allowed.
+4. Base the answer only on query results; show the SQL you used in a code block.
+
+### Cross questions (span both)
+When a question needs BOTH (e.g. "the gaming OLED TV — tell me its price and specs"):
+1. First search the documents to identify the product/entity and gather context.
+2. Then query the structured dataset using the name/keywords you found. Names may not match
+   exactly — use the document context to pick the right row.
+3. Synthesize both into one answer. Do NOT pre-assume the two sources are linked; connect
+   them at query time using the context, and cite each source.
+
 ## Response Guidelines
 
 ### Formatting

--- a/packages/backend/app/ddb/datasets.py
+++ b/packages/backend/app/ddb/datasets.py
@@ -1,0 +1,41 @@
+from boto3.dynamodb.conditions import Key
+
+from app.ddb.client import get_table, now_iso
+from app.ddb.models import Dataset, DatasetData, DdbKey
+
+
+def make_dataset_key(project_id: str, dataset_id: str) -> DdbKey:
+    return {"PK": f"PROJ#{project_id}", "SK": f"DATASET#{dataset_id}"}
+
+
+def get_dataset_item(project_id: str, dataset_id: str) -> Dataset | None:
+    table = get_table()
+    response = table.get_item(Key=make_dataset_key(project_id, dataset_id))
+    item = response.get("Item")
+    return Dataset(**item) if item else None
+
+
+def put_dataset_item(project_id: str, dataset_id: str, data: DatasetData) -> None:
+    table = get_table()
+    now = now_iso()
+    item = {
+        **make_dataset_key(project_id, dataset_id),
+        "data": data.model_dump(),
+        "created_at": now,
+        "updated_at": now,
+    }
+    table.put_item(Item=item)
+
+
+def query_datasets(project_id: str) -> list[Dataset]:
+    """Query all datasets for a project (PK=PROJ#{id}, SK begins_with DATASET#)."""
+    table = get_table()
+    response = table.query(
+        KeyConditionExpression=Key("PK").eq(f"PROJ#{project_id}") & Key("SK").begins_with("DATASET#"),
+    )
+    return [Dataset(**item) for item in response.get("Items", [])]
+
+
+def delete_dataset_item(project_id: str, dataset_id: str) -> None:
+    table = get_table()
+    table.delete_item(Key=make_dataset_key(project_id, dataset_id))

--- a/packages/backend/app/ddb/models.py
+++ b/packages/backend/app/ddb/models.py
@@ -53,6 +53,26 @@ class Document(BaseModel):
     updated_at: str
 
 
+class DatasetData(BaseModel):
+    """Structured dataset (Parquet) reference for Text2SQL queries."""
+
+    dataset_id: str
+    project_id: str
+    name: str
+    description: str = ""
+    dataset_s3_uri: str
+    reference_s3_uri: str | None = None
+    row_count: int | None = None
+    columns: list[str] | None = None
+    source_document_id: str | None = None
+
+
+class Dataset(BaseModel):
+    data: DatasetData
+    created_at: str
+    updated_at: str
+
+
 class WorkflowData(BaseModel):
     execution_arn: str
     file_name: str

--- a/packages/backend/app/duckdb.py
+++ b/packages/backend/app/duckdb.py
@@ -1,3 +1,5 @@
+import re
+
 import duckdb
 from pydantic import BaseModel
 
@@ -122,3 +124,81 @@ def query_agents(user_id: str, project_id: str) -> list[AgentListItem]:
         )
 
     return agents
+
+
+# ── Dataset (Parquet) preview & query ──────────────────────────────────────
+# DuckDB reads the Parquet directly from S3 via httpfs, so only the requested
+# page is materialized regardless of dataset size.
+
+_READ_ONLY_RE = re.compile(r"^\s*(select|with)\b", re.IGNORECASE)
+_FORBIDDEN_RE = re.compile(
+    r"\b(insert|update|delete|drop|create|alter|attach|copy|install|load|"
+    r"pragma|set|export|import|call)\b",
+    re.IGNORECASE,
+)
+_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
+
+
+def is_read_only_sql(query: str) -> bool:
+    """Allow only a single SELECT/WITH statement (reject DDL/DML/multi-statement)."""
+    stripped = query.strip().rstrip(";")
+    if not _READ_ONLY_RE.match(stripped):
+        return False
+    without_strings = _STRING_LITERAL_RE.sub("''", stripped)
+    if ";" in without_strings:
+        return False
+    return not _FORBIDDEN_RE.search(without_strings)
+
+
+def _rows_to_dicts(cursor) -> tuple[list[str], list[dict]]:
+    columns = [d[0] for d in cursor.description]
+    rows = [dict(zip(columns, row, strict=False)) for row in cursor.fetchall()]
+    return columns, rows
+
+
+def get_dataset_schema(dataset_s3_uri: str) -> list[dict]:
+    """Return column name/type for a Parquet dataset."""
+    conn = get_duckdb_connection()
+    safe = dataset_s3_uri.replace("'", "''")
+    result = conn.execute(f"DESCRIBE SELECT * FROM read_parquet('{safe}')").fetchall()
+    return [{"name": r[0], "type": r[1]} for r in result]
+
+
+def get_dataset_rows(dataset_s3_uri: str, offset: int = 0, limit: int = 10) -> dict:
+    """Return a page of rows plus columns from a Parquet dataset."""
+    conn = get_duckdb_connection()
+    safe = dataset_s3_uri.replace("'", "''")
+    cursor = conn.execute(f"SELECT * FROM read_parquet('{safe}') OFFSET {int(offset)} LIMIT {int(limit)}")
+    columns, rows = _rows_to_dicts(cursor)
+    return {"columns": columns, "rows": rows}
+
+
+def run_dataset_query(dataset_s3_uri: str, query: str, offset: int = 0, limit: int = 10) -> dict:
+    """Run a read-only SQL query against a dataset (table 'data'), paginated.
+
+    The user query is wrapped as a subquery so results are returned a page at a
+    time (LIMIT/OFFSET) even for `SELECT * FROM data`. One extra row is fetched to
+    report whether more pages exist.
+    """
+    if not is_read_only_sql(query):
+        raise ValueError("Only read-only SELECT/WITH queries are allowed.")
+
+    conn = get_duckdb_connection()
+    safe = dataset_s3_uri.replace("'", "''")
+    conn.execute(f"CREATE OR REPLACE TEMP VIEW data AS SELECT * FROM read_parquet('{safe}')")
+    inner = query.strip().rstrip(";")
+    offset = max(0, offset)
+    limit = max(1, min(limit, 100))
+    paged = f"SELECT * FROM ({inner}) AS _q OFFSET {offset} LIMIT {limit + 1}"
+    cursor = conn.execute(paged)
+    columns = [d[0] for d in cursor.description]
+    fetched = cursor.fetchall()
+    has_more = len(fetched) > limit
+    rows = [dict(zip(columns, r, strict=False)) for r in fetched[:limit]]
+    return {
+        "columns": columns,
+        "rows": rows,
+        "offset": offset,
+        "limit": limit,
+        "has_more": has_more,
+    }

--- a/packages/backend/app/main.py
+++ b/packages/backend/app/main.py
@@ -5,6 +5,7 @@ from app.routers import (
     agents,
     artifacts,
     chat,
+    datasets,
     documents,
     graph,
     health,
@@ -27,6 +28,7 @@ app = FastAPI(
         {"name": "prompts", "description": "프롬프트 관리"},
         {"name": "sagemaker", "description": "SageMaker 엔드포인트 관리"},
         {"name": "graph", "description": "지식 그래프 관리"},
+        {"name": "datasets", "description": "정형 데이터셋 조회"},
         {"name": "templates", "description": "템플릿 관리"},
     ]
 )
@@ -42,6 +44,7 @@ app.add_middleware(
 app.include_router(agents.router)
 app.include_router(artifacts.router)
 app.include_router(chat.router)
+app.include_router(datasets.router)
 app.include_router(documents.router)
 app.include_router(graph.router)
 app.include_router(health.router)

--- a/packages/backend/app/routers/datasets.py
+++ b/packages/backend/app/routers/datasets.py
@@ -1,0 +1,91 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.ddb.datasets import get_dataset_item, query_datasets
+from app.duckdb import (
+    get_dataset_rows,
+    get_dataset_schema,
+    run_dataset_query,
+)
+
+router = APIRouter(prefix="/projects/{project_id}/datasets", tags=["datasets"])
+
+
+class DatasetResponse(BaseModel):
+    dataset_id: str
+    name: str
+    description: str
+    row_count: int | None
+    columns: list[str] | None
+    source_document_id: str | None
+    reference_s3_uri: str | None
+
+    @classmethod
+    def from_dataset(cls, ds) -> "DatasetResponse":
+        d = ds.data
+        return cls(
+            dataset_id=d.dataset_id,
+            name=d.name,
+            description=d.description,
+            row_count=d.row_count,
+            columns=d.columns,
+            source_document_id=d.source_document_id,
+            reference_s3_uri=d.reference_s3_uri,
+        )
+
+
+class DatasetQueryRequest(BaseModel):
+    query: str
+    offset: int = 0
+    limit: int = 10
+
+
+@router.get("")
+def list_datasets(project_id: str, source_document_id: str | None = None) -> list[DatasetResponse]:
+    """List datasets for a project, optionally filtered by source document."""
+    datasets = query_datasets(project_id)
+    if source_document_id:
+        datasets = [ds for ds in datasets if ds.data.source_document_id == source_document_id]
+    return [DatasetResponse.from_dataset(ds) for ds in datasets]
+
+
+@router.get("/{dataset_id}/schema")
+def dataset_schema(project_id: str, dataset_id: str) -> dict:
+    ds = get_dataset_item(project_id, dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    return {"columns": get_dataset_schema(ds.data.dataset_s3_uri)}
+
+
+@router.get("/{dataset_id}/rows")
+def dataset_rows(project_id: str, dataset_id: str, offset: int = 0, limit: int = 10) -> dict:
+    ds = get_dataset_item(project_id, dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    limit = max(1, min(limit, 100))
+    result = get_dataset_rows(ds.data.dataset_s3_uri, offset=offset, limit=limit)
+    return {
+        **result,
+        "offset": offset,
+        "limit": limit,
+        "row_count": ds.data.row_count,
+    }
+
+
+@router.post("/{dataset_id}/query")
+def dataset_query(project_id: str, dataset_id: str, request: DatasetQueryRequest) -> dict:
+    """Run a read-only SQL query against the dataset (table name: data)."""
+    ds = get_dataset_item(project_id, dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    try:
+        return run_dataset_query(
+            ds.data.dataset_s3_uri,
+            request.query,
+            offset=request.offset,
+            limit=request.limit,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:  # noqa: BLE001 - surface query errors to the user
+        raise HTTPException(status_code=400, detail=f"Query failed: {e}") from e

--- a/packages/backend/app/routers/documents.py
+++ b/packages/backend/app/routers/documents.py
@@ -115,6 +115,7 @@ class StepProgress(BaseModel):
     status: str
     label: str
     error: str | None = None
+    reason: str | None = None
     qa_regen: dict | None = None
 
 
@@ -161,6 +162,8 @@ def get_documents_progress(project_id: str) -> list[DocumentProgress]:
                 step = StepProgress(status=value["status"], label=value["label"])
                 if "error" in value:
                     step.error = value["error"]
+                if "reason" in value:
+                    step.reason = value["reason"]
                 if "qa_regen" in value:
                     step.qa_regen = value["qa_regen"]
                 steps[key] = step

--- a/packages/backend/app/routers/projects.py
+++ b/packages/backend/app/routers/projects.py
@@ -265,6 +265,8 @@ async def delete_project(project_id: str, user_id: str = Header(alias="x-user-id
     try:
         lancedb_drop_table(DropTableInput(project_id=project_id))
         lancedb_delete_graph_keywords(DeleteGraphKeywordsByProjectIdInput(project_id=project_id))
+        # Per-project dataset catalog table is named "{project_id}_datasets".
+        lancedb_drop_table(DropTableInput(project_id=f"{project_id}_datasets"))
         deleted_info.lancedb_objects_deleted = 1
     except LanceDbError as e:
         deleted_info.lancedb_error = str(e)

--- a/packages/common/constructs/src/app/mcp/data-mcp.ts
+++ b/packages/common/constructs/src/app/mcp/data-mcp.ts
@@ -1,0 +1,161 @@
+import { AssetHashType, Duration } from 'aws-cdk-lib';
+import {
+  Architecture,
+  Code,
+  Function as LambdaFunction,
+  LayerVersion,
+  Runtime,
+} from 'aws-cdk-lib/aws-lambda';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Table } from 'aws-cdk-lib/aws-dynamodb';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SSM_KEYS } from '../../constants/ssm-keys.js';
+
+const LAYER_PLATFORM = 'manylinux2014_aarch64';
+// DuckDB publishes wheels only up to cp313 (no cp314 yet), so this Lambda pins
+// to Python 3.13 independently of the other 3.14 functions.
+const LAYER_PYTHON_VERSION = '3.13';
+const PYTHON_RUNTIME = Runtime.PYTHON_3_13;
+
+/**
+ * Data MCP Lambda: exposes search_datasets / describe_dataset / run_sql over
+ * project Parquet datasets. Python + DuckDB reads S3 Parquet (pyarrow + s3fs);
+ * search_datasets delegates to the LanceDB service for the per-project catalog.
+ */
+export class DataMcp extends Construct {
+  public readonly function: LambdaFunction;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const backendTableName = StringParameter.valueForStringParameter(
+      this,
+      SSM_KEYS.BACKEND_TABLE_NAME,
+    );
+    const backendTable = Table.fromTableName(
+      this,
+      'BackendTable',
+      backendTableName,
+    );
+
+    const documentStorageBucketName = StringParameter.valueForStringParameter(
+      this,
+      SSM_KEYS.DOCUMENT_STORAGE_BUCKET_NAME,
+    );
+    const documentStorageBucket = Bucket.fromBucketName(
+      this,
+      'DocumentStorageBucket',
+      documentStorageBucketName,
+    );
+
+    // search_datasets hybrid-searches the per-project dataset catalog via the
+    // LanceDB service Lambda.
+    const lancedbFunctionArn = StringParameter.valueForStringParameter(
+      this,
+      SSM_KEYS.LANCE_SERVICE_FUNCTION_ARN,
+    );
+
+    // pyarrow + s3fs read the Parquet from S3 and hand an Arrow table to DuckDB,
+    // avoiding DuckDB's httpfs extension (which fails to download on Lambda's
+    // arm64 platform for the pinned DuckDB version).
+    const duckdbLayer = new LayerVersion(this, 'DuckDbLayer', {
+      layerVersionName: 'idp-v2-data-mcp-duckdb',
+      description: 'DuckDB, pyarrow, s3fs for the Data MCP Lambda',
+      compatibleRuntimes: [PYTHON_RUNTIME],
+      compatibleArchitectures: [Architecture.ARM_64],
+      code: this.createLayerCode(['duckdb', 'pyarrow', 's3fs'], 'data-mcp'),
+    });
+
+    this.function = new LambdaFunction(this, 'Function', {
+      functionName: 'idp-v2-data-mcp',
+      runtime: PYTHON_RUNTIME,
+      architecture: Architecture.ARM_64,
+      handler: 'index.handler',
+      timeout: Duration.minutes(2),
+      // 2 GB: pyarrow loads whole Parquet files into memory, and JOINs register
+      // several datasets at once. Headroom for ~100k-row datasets and multi-table
+      // queries (see MAX_TOTAL_ROWS guard in index.py). More memory also raises
+      // the CPU share, speeding up DuckDB.
+      memorySize: 2048,
+      code: Code.fromAsset(
+        path.resolve(process.cwd(), '../../packages/lambda/data-mcp'),
+      ),
+      layers: [duckdbLayer],
+      environment: {
+        BACKEND_TABLE_NAME: backendTableName,
+        LANCEDB_FUNCTION_ARN: lancedbFunctionArn,
+      },
+    });
+
+    this.function.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['lambda:InvokeFunction'],
+        resources: [lancedbFunctionArn],
+      }),
+    );
+
+    backendTable.grantReadData(this.function);
+    documentStorageBucket.grantRead(this.function);
+  }
+
+  /**
+   * Build a Lambda layer by pip-installing manylinux arm64 wheels.
+   * Mirrors the createLayerCode pattern in workflow-stack.ts.
+   */
+  private createLayerCode(packages: string[], layerName: string): Code {
+    const quotedPackages = packages.map((p) => `'${p}'`).join(' ');
+    const layerDir = path.resolve(
+      process.cwd(),
+      `../../packages/infra/src/lambda-layers/${layerName}`,
+    );
+    if (!fs.existsSync(layerDir)) {
+      fs.mkdirSync(layerDir, { recursive: true });
+    }
+    fs.writeFileSync(
+      path.join(layerDir, 'requirements.txt'),
+      packages.join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(layerDir, '.platform'),
+      `${LAYER_PLATFORM}\n${LAYER_PYTHON_VERSION}\n`,
+    );
+
+    const pipArgs =
+      `--platform ${LAYER_PLATFORM} ` +
+      `--python-version ${LAYER_PYTHON_VERSION} ` +
+      `--implementation cp ` +
+      `--only-binary=:all: ${quotedPackages}`;
+
+    return Code.fromAsset(layerDir, {
+      assetHashType: AssetHashType.SOURCE,
+      bundling: {
+        image: PYTHON_RUNTIME.bundlingImage,
+        command: [
+          'bash',
+          '-c',
+          `pip install -t /asset-output/python ${pipArgs}`,
+        ],
+        local: {
+          tryBundle(outputDir: string): boolean {
+            try {
+              const pythonDir = path.join(outputDir, 'python');
+              fs.mkdirSync(pythonDir, { recursive: true });
+              execSync(`pip install -t "${pythonDir}" ${pipArgs}`, {
+                stdio: 'inherit',
+              });
+              return true;
+            } catch (e) {
+              console.error(`Local bundling failed: ${e}`);
+              return false;
+            }
+          },
+        },
+      },
+    });
+  }
+}

--- a/packages/common/constructs/src/app/mcp/index.ts
+++ b/packages/common/constructs/src/app/mcp/index.ts
@@ -1,3 +1,4 @@
 export * from './search-mcp.js';
 export * from './image-mcp.js';
 export * from './qa-mcp.js';
+export * from './data-mcp.js';

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@codemirror/lang-sql": "^6.10.0",
     "@types/d3-cloud": "^1.2.9",
+    "@uiw/react-codemirror": "^4.25.10",
     "d3-cloud": "^1.2.9",
     "d3-force": "^3.0.0",
     "framer-motion": "^12.35.0"

--- a/packages/frontend/src/components/DatasetView.tsx
+++ b/packages/frontend/src/components/DatasetView.tsx
@@ -1,0 +1,297 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, ChevronLeft, ChevronRight, Play } from 'lucide-react';
+import CodeMirror from '@uiw/react-codemirror';
+import { sql } from '@codemirror/lang-sql';
+import { useAwsClient } from '../hooks/useAwsClient';
+
+export interface DatasetMeta {
+  dataset_id: string;
+  name: string;
+  description: string;
+  row_count: number | null;
+  columns: string[] | null;
+  source_document_id: string | null;
+  reference_s3_uri: string | null;
+}
+
+interface QueryResponse {
+  columns: string[];
+  rows: Record<string, unknown>[];
+  offset: number;
+  limit: number;
+  has_more: boolean;
+}
+
+const PAGE_SIZE = 10;
+const DEFAULT_QUERY = 'SELECT * FROM data';
+
+interface DatasetViewProps {
+  projectId: string;
+  // Sheet list and selection are owned by the parent (WorkflowDetailModal) so the
+  // sheet selector can live in the header bar. This component renders the SQL
+  // workbench for the currently selected sheet.
+  datasets: DatasetMeta[];
+  selectedId: string | null;
+  // True while the parent is still fetching the dataset list; show a spinner
+  // rather than the "no dataset" empty state to avoid a flash.
+  loadingList?: boolean;
+}
+
+/**
+ * Dataset (structured data) SQL workbench: edit a read-only SQL query
+ * (CodeMirror) against the selected sheet and page through results 10 rows at a
+ * time. The backend wraps the query so even `SELECT * FROM data` is paginated.
+ */
+export default function DatasetView({
+  projectId,
+  datasets,
+  selectedId,
+  loadingList = false,
+}: DatasetViewProps) {
+  const { t } = useTranslation();
+  const { fetchApi } = useAwsClient();
+  const fetchApiRef = useRef(fetchApi);
+  fetchApiRef.current = fetchApi;
+
+  // The SQL currently being edited, and the SQL that produced the shown result.
+  const [queryText, setQueryText] = useState(DEFAULT_QUERY);
+  const [ranQuery, setRanQuery] = useState(DEFAULT_QUERY);
+  const [offset, setOffset] = useState(0);
+  const [result, setResult] = useState<QueryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = datasets.find((d) => d.dataset_id === selectedId) ?? null;
+
+  // Run a query (a specific page of it) against the selected dataset.
+  const runPage = useCallback(
+    (datasetId: string, query: string, pageOffset: number) => {
+      setLoading(true);
+      setError(null);
+      fetchApiRef
+        .current<QueryResponse>(
+          `projects/${projectId}/datasets/${datasetId}/query`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              query,
+              offset: pageOffset,
+              limit: PAGE_SIZE,
+            }),
+          },
+        )
+        .then((res) => {
+          setResult(res);
+          setOffset(pageOffset);
+          setRanQuery(query);
+        })
+        .catch((e: unknown) => {
+          setResult(null);
+          setError(
+            e instanceof Error
+              ? e.message
+              : t('dataset.queryFailed', 'Query failed'),
+          );
+        })
+        .finally(() => setLoading(false));
+    },
+    [projectId, t],
+  );
+
+  // On dataset change: reset to the default query, first page.
+  useEffect(() => {
+    if (!selectedId) return;
+    setQueryText(DEFAULT_QUERY);
+    runPage(selectedId, DEFAULT_QUERY, 0);
+  }, [selectedId, runPage]);
+
+  const runQuery = () => {
+    if (!selectedId || !queryText.trim()) return;
+    runPage(selectedId, queryText, 0);
+  };
+
+  const goPage = (nextOffset: number) => {
+    if (!selectedId || nextOffset < 0 || loading) return;
+    runPage(selectedId, ranQuery, nextOffset);
+  };
+
+  if (loadingList) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  if (datasets.length === 0) {
+    return (
+      <div className="w-full h-full p-6 text-center text-sm text-slate-400">
+        {t('dataset.none', 'No structured dataset found for this document.')}
+      </div>
+    );
+  }
+
+  const totalRows = selected?.row_count ?? null;
+  const isDark =
+    typeof document !== 'undefined' &&
+    document.documentElement.classList.contains('dark');
+
+  return (
+    <div className="w-full h-full flex flex-col p-4 gap-3 min-h-0">
+      {/* Meta */}
+      {selected && (
+        <div className="flex-shrink-0 text-[12px] text-slate-500 dark:text-slate-400">
+          <span className="font-medium text-slate-700 dark:text-slate-200">
+            {selected.name}
+          </span>
+          {totalRows != null && (
+            <span className="ml-2">
+              {t('dataset.totalRows', '{{count}} rows', { count: totalRows })}
+            </span>
+          )}
+          {selected.columns && (
+            <span className="ml-2">· {selected.columns.length} cols</span>
+          )}
+        </div>
+      )}
+
+      {/* SQL editor (read-only DuckDB SQL, table name: data) */}
+      <div className="flex-shrink-0 flex flex-col gap-1.5">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] font-medium text-slate-500 dark:text-slate-400">
+            {t('dataset.sqlEditor', 'SQL (read-only, table name: data)')}
+          </span>
+          <span className="text-[10px] text-slate-400">
+            {t('dataset.runHint', 'Cmd/Ctrl+Enter to run')}
+          </span>
+        </div>
+        <div className="rounded-lg border border-black/10 dark:border-[#3b4264] overflow-hidden">
+          <CodeMirror
+            value={queryText}
+            height="200px"
+            theme={isDark ? 'dark' : 'light'}
+            extensions={[sql()]}
+            onChange={setQueryText}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                e.preventDefault();
+                runQuery();
+              }
+            }}
+            basicSetup={{
+              lineNumbers: true,
+              highlightActiveLine: true,
+              autocompletion: true,
+            }}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={runQuery}
+            disabled={loading || !queryText.trim()}
+            className="flex items-center gap-1 px-3 py-1.5 text-[12px] font-medium rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Play className="w-3.5 h-3.5" />
+            )}
+            {t('dataset.run', 'Run')}
+          </button>
+          <button
+            onClick={() => {
+              setQueryText(DEFAULT_QUERY);
+              if (selectedId) runPage(selectedId, DEFAULT_QUERY, 0);
+            }}
+            disabled={loading}
+            className="px-2 py-1.5 text-[12px] text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 disabled:opacity-50"
+          >
+            {t('dataset.reset', 'Reset')}
+          </button>
+          {error && <span className="text-[11px] text-red-500">{error}</span>}
+        </div>
+      </div>
+
+      {/* Result grid */}
+      <div className="flex-1 min-h-0 border border-black/[0.08] dark:border-[#2a2f45] rounded-lg overflow-auto">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+          </div>
+        ) : result && result.rows.length > 0 ? (
+          <table className="min-w-full text-[12px] border-collapse">
+            <thead className="bg-slate-100 dark:bg-white/[0.06] sticky top-0">
+              <tr>
+                {result.columns.map((col) => (
+                  <th
+                    key={col}
+                    className="px-2.5 py-1.5 text-left font-semibold text-slate-600 dark:text-slate-300 border-b border-black/[0.08] dark:border-[#2a2f45] whitespace-nowrap"
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {result.rows.map((row, i) => (
+                <tr
+                  key={i}
+                  className="odd:bg-black/[0.02] dark:odd:bg-white/[0.02]"
+                >
+                  {result.columns.map((col) => (
+                    <td
+                      key={col}
+                      className="px-2.5 py-1 text-slate-600 dark:text-slate-300 border-b border-black/[0.04] dark:border-white/[0.04] whitespace-nowrap"
+                    >
+                      {formatCell(row[col])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="py-12 text-center text-sm text-slate-400">
+            {t('dataset.noRows', 'No rows')}
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {result && (result.rows.length > 0 || offset > 0) && (
+        <div className="flex-shrink-0 flex items-center justify-between text-[12px] text-slate-500">
+          <span>
+            {result.rows.length > 0
+              ? `${offset + 1}–${offset + result.rows.length}`
+              : '0'}
+            {result.has_more ? '+' : ''}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => goPage(offset - PAGE_SIZE)}
+              disabled={offset === 0 || loading}
+              className="p-1 rounded hover:bg-black/[0.05] dark:hover:bg-white/[0.06] disabled:opacity-40"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => goPage(offset + PAGE_SIZE)}
+              disabled={loading || !result.has_more}
+              className="p-1 rounded hover:bg-black/[0.05] dark:hover:bg-white/[0.06] disabled:opacity-40"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}

--- a/packages/frontend/src/components/DocumentUploadModal.tsx
+++ b/packages/frontend/src/components/DocumentUploadModal.tsx
@@ -57,7 +57,7 @@ const PROJECT_LANG_TO_OCR_LANG: Record<string, string> = {
   fi: 'fi',
 };
 
-type UploadTab = 'file' | 'web';
+type UploadTab = 'file' | 'data' | 'web';
 
 export interface DocumentProcessingOptions {
   use_bda: boolean;
@@ -86,6 +86,31 @@ interface DocumentUploadModalProps {
     files: File[],
     options: DocumentProcessingOptions,
   ) => Promise<void>;
+}
+
+// Format a byte count with an appropriate unit. Using MB alone rounds small
+// files (most spreadsheets/CSVs are tens of KB) down to "0.0 MB".
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+// Accepted file extensions per tab. The File tab handles documents/media; the
+// Data tab handles spreadsheets only (structured datasets). The <input accept>
+// attribute only filters the picker dialog, NOT drag-and-drop, so these sets are
+// also used to filter dropped/selected files explicitly.
+const FILE_TAB_ACCEPT =
+  '.pdf,.doc,.docx,.ppt,.pptx,.txt,.md,.png,.jpg,.jpeg,.gif,.tiff,.mp4,.mov,.avi,.mp3,.wav,.flac,.dxf';
+const DATA_TAB_ACCEPT = '.xlsx,.xls,.csv,.tsv';
+
+function acceptToExtensions(accept: string): string[] {
+  return accept.split(',').map((s) => s.trim().toLowerCase());
+}
+
+function fileMatchesAccept(file: File, accept: string): boolean {
+  const name = file.name.toLowerCase();
+  return acceptToExtensions(accept).some((ext) => name.endsWith(ext));
 }
 
 export default function DocumentUploadModal({
@@ -242,20 +267,33 @@ export default function DocumentUploadModal({
     setIsDragging(false);
   }, []);
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
+  // Keep only files whose extension matches the active tab (Excel belongs in the
+  // Data tab, documents in the File tab). accept on <input> filters the picker
+  // but not drag-and-drop, so filter explicitly here for both paths.
+  const acceptForTab = activeTab === 'data' ? DATA_TAB_ACCEPT : FILE_TAB_ACCEPT;
+  const filterAccepted = useCallback(
+    (incoming: File[]) =>
+      incoming.filter((f) => fileMatchesAccept(f, acceptForTab)),
+    [acceptForTab],
+  );
 
-    const droppedFiles = Array.from(e.dataTransfer.files);
-    if (droppedFiles.length > 0) {
-      setFiles((prev) => [...prev, ...droppedFiles]);
-    }
-  }, []);
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+
+      const droppedFiles = filterAccepted(Array.from(e.dataTransfer.files));
+      if (droppedFiles.length > 0) {
+        setFiles((prev) => [...prev, ...droppedFiles]);
+      }
+    },
+    [filterAccepted],
+  );
 
   const handleFileSelect = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const fileArray = Array.from(e.target.files ?? []);
+      const fileArray = filterAccepted(Array.from(e.target.files ?? []));
       if (fileArray.length > 0) {
         setFiles((prev) => [...prev, ...fileArray]);
       }
@@ -264,7 +302,7 @@ export default function DocumentUploadModal({
         fileInputRef.current.value = '';
       }
     },
-    [],
+    [filterAccepted],
   );
 
   const removeFile = useCallback((index: number) => {
@@ -373,6 +411,18 @@ export default function DocumentUploadModal({
         transcribe_language_code: 'ko-KR',
         transcribe_language_options: [],
       });
+    } else if (activeTab === 'data') {
+      if (files.length === 0) return;
+      // Structured data: no BDA/OCR/Transcribe. The backend classifies
+      // xlsx/xls/csv/tsv as datasets and runs the dataset pipeline.
+      await onUpload(files, {
+        use_bda: false,
+        use_ocr: false,
+        use_transcribe: false,
+        language,
+      });
+      setFiles([]);
+      setPdfPageCounts(new Map());
     } else {
       if (!webUrl) return;
       const webreqFile = createWebreqFile();
@@ -431,7 +481,9 @@ export default function DocumentUploadModal({
   useModal({ isOpen, onClose: handleClose, disableClose: uploading });
 
   const isUploadDisabled =
-    activeTab === 'file' ? files.length === 0 : !webUrl.trim();
+    activeTab === 'file' || activeTab === 'data'
+      ? files.length === 0
+      : !webUrl.trim();
 
   if (!isOpen) return null;
 
@@ -487,6 +539,18 @@ export default function DocumentUploadModal({
           >
             <FileUp className="h-4 w-4" />
             {t('documents.tabFile', 'File')}
+          </button>
+          <button
+            onClick={() => setActiveTab('data')}
+            disabled={uploading}
+            className={`flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'data'
+                ? 'text-blue-600 border-b-2 border-blue-600'
+                : 'text-[#64748b] hover:text-[#334155] dark:hover:text-[#cbd5e1]'
+            } disabled:opacity-50`}
+          >
+            <Layers className="h-4 w-4" />
+            {t('documents.tabData', 'Data')}
           </button>
           <button
             onClick={() => setActiveTab('web')}
@@ -553,7 +617,7 @@ export default function DocumentUploadModal({
                     ref={fileInputRef}
                     type="file"
                     multiple
-                    accept=".pdf,.doc,.docx,.ppt,.pptx,.txt,.md,.png,.jpg,.jpeg,.gif,.tiff,.mp4,.mov,.avi,.mp3,.wav,.flac,.dxf"
+                    accept={FILE_TAB_ACCEPT}
                     className="hidden"
                     onChange={handleFileSelect}
                     disabled={uploading}
@@ -579,7 +643,7 @@ export default function DocumentUploadModal({
                           {file.name}
                         </span>
                         <span className="text-xs text-[#94a3b8]">
-                          {(file.size / 1024 / 1024).toFixed(1)} MB
+                          {formatFileSize(file.size)}
                         </span>
                         <button
                           onClick={() => removeFile(index)}
@@ -933,6 +997,106 @@ export default function DocumentUploadModal({
                 </div>
               )}
             </>
+          ) : activeTab === 'data' ? (
+            <>
+              {/* Data Drop Zone */}
+              <div
+                className={`relative border-2 border-dashed rounded-xl transition-colors ${
+                  isDragging
+                    ? 'border-blue-400 bg-blue-50 dark:bg-blue-500/10'
+                    : 'border-black/10 dark:border-[#3b4264] dark:bg-[#0d1117] hover:border-black/20 dark:hover:border-[#4f5680]'
+                }`}
+                onDragOver={handleDragOver}
+                onDragEnter={handleDragEnter}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+              >
+                <label
+                  htmlFor="data-upload-input"
+                  className="flex flex-col items-center justify-center p-8 cursor-pointer"
+                >
+                  <CloudUpload
+                    className={`h-12 w-12 mb-3 ${
+                      isDragging ? 'text-blue-500' : 'text-[#94a3b8]'
+                    }`}
+                    strokeWidth={1.5}
+                  />
+                  <p
+                    className={`text-sm font-medium mb-1 ${
+                      isDragging
+                        ? 'text-blue-700'
+                        : 'text-[#334155] dark:text-[#cbd5e1]'
+                    }`}
+                  >
+                    {isDragging
+                      ? t('documents.dropHere', 'Drop files here')
+                      : t(
+                          'documents.dragDrop',
+                          'Drag & drop files or click to browse',
+                        )}
+                  </p>
+                  <p className="text-xs text-[#64748b] text-center">
+                    {t(
+                      'documents.dataFormats',
+                      'Excel (.xlsx, .xls), CSV, TSV (max 500MB)',
+                    )}
+                  </p>
+                  <input
+                    id="data-upload-input"
+                    type="file"
+                    multiple
+                    accept={DATA_TAB_ACCEPT}
+                    className="hidden"
+                    onChange={handleFileSelect}
+                    disabled={uploading}
+                  />
+                </label>
+              </div>
+
+              {/* Selected Files */}
+              {files.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-[#334155] dark:text-[#cbd5e1]">
+                    {t('documents.selectedFiles', 'Selected Files')} (
+                    {files.length})
+                  </p>
+                  <div className="max-h-32 overflow-y-auto space-y-1">
+                    {files.map((file, index) => (
+                      <div
+                        key={`${file.name}-${index}`}
+                        className="flex items-center gap-2 p-2 bg-transparent dark:bg-[#0d1117] rounded-lg"
+                      >
+                        <Layers className="h-4 w-4 text-[#94a3b8] flex-shrink-0" />
+                        <span className="text-sm text-[#475569] dark:text-[#cbd5e1] truncate flex-1">
+                          {file.name}
+                        </span>
+                        <span className="text-xs text-[#94a3b8]">
+                          {formatFileSize(file.size)}
+                        </span>
+                        <button
+                          onClick={() => removeFile(index)}
+                          disabled={uploading}
+                          className="p-1 hover:bg-white/50 dark:hover:bg-[#1e2235] rounded transition-colors disabled:opacity-50"
+                        >
+                          <X className="h-3.5 w-3.5 text-[#64748b]" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Data info */}
+              <div className="flex items-start gap-2 p-2.5 bg-blue-50 dark:bg-blue-500/[0.07] border border-blue-200 dark:border-blue-400/20 rounded-lg">
+                <Info className="h-3.5 w-3.5 text-blue-500 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+                <p className="text-xs text-blue-700 dark:text-blue-300">
+                  {t(
+                    'documents.dataUploadHint',
+                    'Structured tables are stored as queryable datasets. Each sheet must be a clean table: merged cells, images/charts, or multi-row headers are rejected and must be fixed and re-uploaded.',
+                  )}
+                </p>
+              </div>
+            </>
           ) : (
             <>
               {/* Web URL Input */}
@@ -1063,6 +1227,11 @@ export default function DocumentUploadModal({
               <>
                 <CloudUpload className="h-4 w-4" />
                 {t('documents.upload', 'Upload')}
+              </>
+            ) : activeTab === 'data' ? (
+              <>
+                <CloudUpload className="h-4 w-4" />
+                {t('documents.uploadData', 'Upload Data')}
               </>
             ) : (
               <>

--- a/packages/frontend/src/components/SidePanel.tsx
+++ b/packages/frontend/src/components/SidePanel.tsx
@@ -180,6 +180,8 @@ const getStatusBadge = (status: string) => {
     reanalyzing:
       'bg-purple-50 text-purple-600 dark:bg-purple-900/20 dark:text-purple-500',
     failed: 'bg-red-50 text-red-600 dark:bg-red-900/20 dark:text-red-500',
+    needs_user_fix:
+      'bg-orange-50 text-orange-600 dark:bg-orange-900/20 dark:text-orange-500',
     uploading:
       'bg-cyan-50 text-cyan-600 dark:bg-cyan-900/20 dark:text-cyan-500',
     uploaded:
@@ -225,6 +227,7 @@ function StepProgressBar({
     'segment_analyzer',
     'graph_builder',
     'document_summarizer',
+    'dataset_process',
   ];
 
   const visibleSteps = STEP_ORDER.filter(
@@ -286,6 +289,7 @@ function StepProgressBar({
             const isActive = step.status === 'in_progress';
             const isDone = step.status === 'completed';
             const isFailed = step.status === 'failed';
+            const isNeedsFix = step.status === 'needs_user_fix';
 
             const hasNumericProgress =
               isActive && segmentProgress && key === 'segment_analyzer';
@@ -299,7 +303,13 @@ function StepProgressBar({
               <div
                 key={key}
                 className="space-y-0.5"
-                title={isFailed && step.error ? step.error : undefined}
+                title={
+                  isFailed && step.error
+                    ? step.error
+                    : isNeedsFix && step.reason
+                      ? step.reason
+                      : undefined
+                }
               >
                 <div className="flex items-center gap-1.5">
                   {isDone && (
@@ -310,6 +320,9 @@ function StepProgressBar({
                   )}
                   {isFailed && (
                     <CircleAlert className="h-3 w-3 text-red-500 flex-shrink-0" />
+                  )}
+                  {isNeedsFix && (
+                    <CircleAlert className="h-3 w-3 text-orange-500 flex-shrink-0" />
                   )}
                   {step.status === 'pending' && (
                     <div className="h-3 w-3 rounded-full border border-slate-300 dark:border-slate-500 flex-shrink-0" />
@@ -323,7 +336,9 @@ function StepProgressBar({
                           ? 'text-blue-700 dark:text-blue-300 font-medium'
                           : isFailed
                             ? 'text-red-600 dark:text-red-400'
-                            : 'text-slate-400 dark:text-slate-500'
+                            : isNeedsFix
+                              ? 'text-orange-600 dark:text-orange-400'
+                              : 'text-slate-400 dark:text-slate-500'
                     }`}
                   >
                     {step.label}
@@ -366,6 +381,21 @@ function StepProgressBar({
                   <p key={key}>
                     <span className="font-medium">{s.label}:</span> {s.error}
                   </p>
+                ))}
+              </div>
+            );
+          })()}
+
+          {/* Needs-user-fix reasons (structured data validation) */}
+          {(() => {
+            const needsFix = visibleSteps.filter(
+              ([, s]) => s.status === 'needs_user_fix' && s.reason,
+            );
+            if (needsFix.length === 0) return null;
+            return (
+              <div className="mt-1.5 p-2 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800/40 rounded text-[10px] text-orange-600 dark:text-orange-400 space-y-0.5">
+                {needsFix.map(([key, s]) => (
+                  <p key={key}>{s.reason}</p>
                 ))}
               </div>
             );

--- a/packages/frontend/src/components/WorkflowDetailModal.tsx
+++ b/packages/frontend/src/components/WorkflowDetailModal.tsx
@@ -26,6 +26,7 @@ import ConfirmModal from './ConfirmModal';
 import { LANGUAGES, CARD_COLORS } from './ProjectSettingsModal';
 import OcrDocumentView from './OcrDocumentView';
 import ExcelViewer from './ExcelViewer';
+import DatasetView, { type DatasetMeta } from './DatasetView';
 import DocumentScanner from './ui/document-scanner';
 import { useAwsClient } from '../hooks/useAwsClient';
 import { useModal } from '../hooks/useModal';
@@ -224,6 +225,40 @@ export default function WorkflowDetailModal({
   const fetchApiRef = useRef(fetchApi);
   fetchApiRef.current = fetchApi;
   const [viewMode, setViewMode] = useState<'document' | 'graph'>('document');
+  // Structured datasets (xlsx/csv/tsv) render a table preview and have no
+  // analysis segments, so segment navigation is hidden for them.
+  const isDataset = isSpreadsheetFileType(workflow.file_type);
+  // Dataset sheets (each Excel sheet = one dataset). Held in the parent so the
+  // sheet selector can live in the header bar (same spot/style as the segment
+  // selector) while DatasetView renders the selected sheet.
+  const [datasets, setDatasets] = useState<DatasetMeta[]>([]);
+  const [datasetsLoading, setDatasetsLoading] = useState(false);
+  const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(
+    null,
+  );
+  useEffect(() => {
+    if (!isDataset) return;
+    let cancelled = false;
+    setDatasetsLoading(true);
+    fetchApiRef
+      .current<DatasetMeta[]>(
+        `projects/${projectId}/datasets?source_document_id=${workflow.document_id}`,
+      )
+      .then((list) => {
+        if (cancelled) return;
+        setDatasets(list);
+        setSelectedDatasetId((prev) => prev ?? list[0]?.dataset_id ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setDatasets([]);
+      })
+      .finally(() => {
+        if (!cancelled) setDatasetsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isDataset, projectId, workflow.document_id]);
   const [graphData, setGraphData] = useState<GraphData | null>(null);
   const [tagCloudData, setTagCloudData] = useState<TagCloudItem[] | null>(null);
   const [graphLoading, setGraphLoading] = useState(false);
@@ -1860,6 +1895,62 @@ export default function WorkflowDetailModal({
                           </div>
                         </div>
                       )}
+
+                    {/* Structured dataset: show the selected sheet's row/column
+                        counts and its generated description (the meta above is
+                        sparse for datasets — no segments/analysis). */}
+                    {isDataset &&
+                      (() => {
+                        const ds =
+                          datasets.find(
+                            (d) => d.dataset_id === selectedDatasetId,
+                          ) ?? datasets[0];
+                        if (!ds) return null;
+                        return (
+                          <div className="space-y-3">
+                            {(ds.row_count != null || ds.columns) && (
+                              <div className="grid grid-cols-2 gap-4">
+                                {ds.row_count != null && (
+                                  <div>
+                                    <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">
+                                      {t(
+                                        'dataset.totalRows',
+                                        '{{count}} rows',
+                                        {
+                                          count: ds.row_count,
+                                        },
+                                      )}
+                                    </p>
+                                    <p className="text-sm text-slate-800 dark:text-slate-200">
+                                      {ds.row_count.toLocaleString()}
+                                    </p>
+                                  </div>
+                                )}
+                                {ds.columns && (
+                                  <div>
+                                    <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">
+                                      {t('dataset.columns', 'Columns')}
+                                    </p>
+                                    <p className="text-sm text-slate-800 dark:text-slate-200">
+                                      {ds.columns.length}
+                                    </p>
+                                  </div>
+                                )}
+                              </div>
+                            )}
+                            {ds.description && (
+                              <div>
+                                <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">
+                                  {t('dataset.description', 'Description')}
+                                </p>
+                                <p className="text-sm text-slate-700 dark:text-slate-300 whitespace-pre-wrap leading-relaxed max-h-64 overflow-y-auto">
+                                  {ds.description}
+                                </p>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })()}
                   </div>
 
                   <hr className="border-black/[0.08] dark:border-white/[0.08]" />
@@ -2020,7 +2111,78 @@ export default function WorkflowDetailModal({
           {/* View Mode Tabs + Navigation */}
           <div className="flex items-center justify-between min-h-[68px] p-4 pr-16 border-b border-black/[0.08] dark:border-[#2a2f45] bg-transparent">
             <div className="flex items-center gap-2">
-              {viewMode === 'document' && (
+              {isDataset && datasets.length > 0 && (
+                <>
+                  {(() => {
+                    const idx = datasets.findIndex(
+                      (d) => d.dataset_id === selectedDatasetId,
+                    );
+                    const go = (next: number) => {
+                      if (next < 0 || next >= datasets.length) return;
+                      setSelectedDatasetId(datasets[next].dataset_id);
+                    };
+                    return (
+                      <>
+                        <button
+                          onClick={() => go(idx - 1)}
+                          disabled={idx <= 0}
+                          className="p-2 hover:bg-slate-100 dark:hover:bg-white/10 rounded-lg transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          <svg
+                            className="h-4 w-4 text-slate-600 dark:text-slate-400"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M15 19l-7-7 7-7"
+                            />
+                          </svg>
+                        </button>
+                        <select
+                          value={selectedDatasetId ?? ''}
+                          onChange={(e) => setSelectedDatasetId(e.target.value)}
+                          className="bg-transparent dark:bg-white/[0.06] border border-black/10 dark:border-white/[0.12] text-slate-800 dark:text-slate-200 text-sm rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 max-w-[280px]"
+                        >
+                          {datasets.map((ds) => (
+                            <option key={ds.dataset_id} value={ds.dataset_id}>
+                              {ds.name}
+                            </option>
+                          ))}
+                        </select>
+                        {datasets.length > 1 && (
+                          <span className="text-sm text-slate-500">
+                            {idx + 1}/{datasets.length}
+                          </span>
+                        )}
+                        <button
+                          onClick={() => go(idx + 1)}
+                          disabled={idx >= datasets.length - 1}
+                          className="p-2 hover:bg-slate-100 dark:hover:bg-white/10 rounded-lg transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          <svg
+                            className="h-4 w-4 text-slate-600 dark:text-slate-400"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M9 5l7 7-7 7"
+                            />
+                          </svg>
+                        </button>
+                      </>
+                    );
+                  })()}
+                </>
+              )}
+              {viewMode === 'document' && !isDataset && (
                 <>
                   <button
                     onClick={() => {
@@ -2294,6 +2456,19 @@ export default function WorkflowDetailModal({
                   </div>
                 )}
               </div>
+            </div>
+          ) : isDataset ? (
+            // Structured data (xlsx/csv/tsv): show the queryable dataset table
+            // (schema + paginated rows + SQL) in the preview area. Datasets have
+            // no analysis segments (total_segments = 0), so this branch takes
+            // precedence over the segment-based views below.
+            <div className="flex-1 min-w-0">
+              <DatasetView
+                projectId={projectId}
+                datasets={datasets}
+                selectedId={selectedDatasetId}
+                loadingList={datasetsLoading}
+              />
             </div>
           ) : (
             <div className="flex-1 flex items-center justify-center p-6 overflow-auto relative min-w-0">

--- a/packages/frontend/src/hooks/useDocuments.ts
+++ b/packages/frontend/src/hooks/useDocuments.ts
@@ -13,7 +13,15 @@ import type {
 } from '../types/project';
 import type { DocumentProcessingOptions } from '../components/DocumentUploadModal';
 
-const EXT_MIME: Record<string, string> = { dxf: 'application/dxf' };
+const EXT_MIME: Record<string, string> = {
+  dxf: 'application/dxf',
+  // Structured data: browsers often leave file.type empty for these, so map by
+  // extension to the MIME types the backend uses to classify datasets.
+  csv: 'text/csv',
+  tsv: 'text/tab-separated-values',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
 const getMimeTypeByExt = (name: string): string => {
   const ext = name.split('.').pop()?.toLowerCase() || '';
   return EXT_MIME[ext] || 'application/octet-stream';
@@ -108,6 +116,7 @@ export function useDocuments({
       segment_analyzer: t('workflow.steps.segmentAiAnalysis'),
       graph_builder: t('workflow.steps.graphBuilder'),
       document_summarizer: t('workflow.steps.documentSummary'),
+      dataset_process: t('workflow.steps.datasetProcess', 'Dataset Processing'),
     }),
     [t],
   );
@@ -127,6 +136,7 @@ export function useDocuments({
               status: string;
               label: string;
               error?: string;
+              reason?: string;
               qa_regen?: { status: string; segment_index: number };
             }
           >;
@@ -148,6 +158,7 @@ export function useDocuments({
                 status: val.status as StepStatus['status'],
                 label: stepLabels[key] || val.label,
                 ...(val.error && { error: val.error }),
+                ...(val.reason && { reason: val.reason }),
               };
             }
             const segAnalyzer = progress.steps.segment_analyzer;
@@ -215,6 +226,7 @@ export function useDocuments({
               status: string;
               label: string;
               error?: string;
+              reason?: string;
               qa_regen?: { status: string; segment_index: number };
             }
           >;
@@ -235,6 +247,7 @@ export function useDocuments({
               status: val.status as StepStatus['status'],
               label: stepLabels[key] || val.label,
               ...(val.error && { error: val.error }),
+              ...(val.reason && { reason: val.reason }),
             };
           }
           const segAnalyzer = progress.steps.segment_analyzer;
@@ -378,14 +391,21 @@ export function useDocuments({
           setTimeout(() => {
             fetchProgressRef.current();
           }, 2000);
-        } else if (data.status === 'completed' || data.status === 'failed') {
+        } else if (
+          data.status === 'completed' ||
+          data.status === 'failed' ||
+          data.status === 'needs_user_fix'
+        ) {
           setWorkflowProgressMap((prev) => {
             if (!prev[data.documentId]) return prev;
             return {
               ...prev,
               [data.documentId]: {
                 ...prev[data.documentId],
-                status: data.status as 'completed' | 'failed',
+                status: data.status as
+                  | 'completed'
+                  | 'failed'
+                  | 'needs_user_fix',
               },
             };
           });
@@ -477,7 +497,9 @@ export function useDocuments({
     const completedDocIds = Object.entries(workflowProgressMap)
       .filter(
         ([, progress]) =>
-          (progress.status === 'completed' || progress.status === 'failed') &&
+          (progress.status === 'completed' ||
+            progress.status === 'failed' ||
+            progress.status === 'needs_user_fix') &&
           progress.qaRegen?.status !== 'in_progress',
       )
       .map(([docId]) => docId);
@@ -508,7 +530,12 @@ export function useDocuments({
         const doc = documents.find((d) => d.document_id === docId);
         // Keep entry if qa_regen is active
         if (newMap[docId]?.qaRegen?.status === 'in_progress') continue;
-        if (doc && (doc.status === 'completed' || doc.status === 'failed')) {
+        if (
+          doc &&
+          (doc.status === 'completed' ||
+            doc.status === 'failed' ||
+            doc.status === 'needs_user_fix')
+        ) {
           delete newMap[docId];
           changed = true;
         }

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -98,6 +98,7 @@
     "reanalyzing": "Re-analyzing",
     "completed": "Completed",
     "failed": "Failed",
+    "needs_user_fix": "Needs Fix",
     "pending": "Pending",
     "uploaded": "Uploaded",
     "deleteConfirm": "Are you sure you want to delete this document?",
@@ -111,7 +112,11 @@
     "filterFailed": "Failed",
     "noMatchingDocuments": "No matching documents",
     "tabFile": "File",
+    "tabData": "Data",
     "tabWeb": "Web",
+    "uploadData": "Upload Data",
+    "dataFormats": "Excel (.xlsx, .xls), CSV, TSV (max 500MB)",
+    "dataUploadHint": "Structured tables are stored as queryable datasets. Each sheet must be a clean table: merged cells, images/charts, or multi-row headers are rejected and must be fixed and re-uploaded.",
     "webUrl": "URL",
     "webUrlPlaceholder": "https://example.com/page",
     "webInstruction": "Instructions",
@@ -130,6 +135,22 @@
     "maxPageHint": "An uploaded document contains up to {{pages}} pages. Officially supported up to 3,000 pages. For PoC, we recommend testing with smaller documents first.",
     "transcribe": "Transcribe",
     "transcribeDesc": "Amazon Transcribe"
+  },
+  "dataset": {
+    "tab": "Data",
+    "none": "No structured dataset found for this document.",
+    "totalRows": "{{count}} rows",
+    "queryPlaceholder": "SELECT * FROM data WHERE ... (read-only)",
+    "run": "Run",
+    "clear": "Clear",
+    "queryFailed": "Query failed",
+    "noRows": "No rows",
+    "queryTruncated": "Result truncated. Add LIMIT or aggregation for complete results.",
+    "sqlEditor": "SQL (read-only, table name: data)",
+    "runHint": "Cmd/Ctrl+Enter to run",
+    "reset": "Reset",
+    "columns": "Columns",
+    "description": "Description"
   },
   "workflow": {
     "title": "Workflow",
@@ -197,7 +218,8 @@
       "buildingSegments": "Building Segments",
       "segmentAiAnalysis": "AI Analysis",
       "graphBuilder": "Knowledge Graph",
-      "documentSummary": "Document Summary"
+      "documentSummary": "Document Summary",
+      "datasetProcess": "Dataset Processing"
     },
     "inProgress": "Processing...",
     "qaRegenInProgress": "Additional analysis (page {{page}})",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -98,6 +98,7 @@
     "reanalyzing": "再分析中",
     "completed": "完了",
     "failed": "失敗",
+    "needs_user_fix": "修正が必要",
     "pending": "保留中",
     "uploaded": "アップロード済み",
     "deleteConfirm": "このドキュメントを削除しますか？",
@@ -111,7 +112,11 @@
     "filterFailed": "失敗",
     "noMatchingDocuments": "一致するドキュメントがありません",
     "tabFile": "ファイル",
+    "tabData": "データ",
     "tabWeb": "ウェブ",
+    "uploadData": "データをアップロード",
+    "dataFormats": "Excel (.xlsx, .xls), CSV, TSV (最大500MB)",
+    "dataUploadHint": "構造化テーブルはクエリ可能なデータセットとして保存されます。各シートは整ったテーブルである必要があります。結合セル、画像/グラフ、複数行ヘッダーがある場合は処理されないため、テーブル形式に整えて再アップロードしてください。",
     "webUrl": "URL",
     "webUrlPlaceholder": "https://example.com/page",
     "webInstruction": "指示",
@@ -130,6 +135,22 @@
     "maxPageHint": "アップロードしたドキュメントに最大{{pages}}ページが含まれています。公式サポートは3,000ページまでです。PoCでは小さなドキュメントで先に検証することをお勧めします。",
     "transcribe": "Transcribe",
     "transcribeDesc": "Amazon Transcribe"
+  },
+  "dataset": {
+    "tab": "データ",
+    "none": "このドキュメントの構造化データセットがありません。",
+    "totalRows": "{{count}}行",
+    "queryPlaceholder": "SELECT * FROM data WHERE ... (読み取り専用)",
+    "run": "実行",
+    "clear": "クリア",
+    "queryFailed": "クエリ失敗",
+    "noRows": "行なし",
+    "queryTruncated": "結果が切り詰められました。完全な結果にはLIMITや集計を使用してください。",
+    "sqlEditor": "SQL (読み取り専用, テーブル名: data)",
+    "runHint": "Cmd/Ctrl+Enterで実行",
+    "reset": "リセット",
+    "columns": "カラム",
+    "description": "説明"
   },
   "workflow": {
     "title": "ワークフロー",
@@ -197,7 +218,8 @@
       "buildingSegments": "セグメント構築",
       "segmentAiAnalysis": "AI分析",
       "graphBuilder": "ナレッジグラフ構築",
-      "documentSummary": "ドキュメント要約"
+      "documentSummary": "ドキュメント要約",
+      "datasetProcess": "データ処理"
     },
     "inProgress": "処理中...",
     "qaRegenInProgress": "追加分析中 (ページ {{page}})",

--- a/packages/frontend/src/i18n/locales/ko.json
+++ b/packages/frontend/src/i18n/locales/ko.json
@@ -98,6 +98,7 @@
     "reanalyzing": "재분석 중",
     "completed": "완료",
     "failed": "실패",
+    "needs_user_fix": "수정 필요",
     "pending": "대기 중",
     "uploaded": "업로드됨",
     "deleteConfirm": "이 문서를 삭제하시겠습니까?",
@@ -111,7 +112,11 @@
     "filterFailed": "실패",
     "noMatchingDocuments": "일치하는 문서가 없습니다",
     "tabFile": "파일",
+    "tabData": "데이터",
     "tabWeb": "웹",
+    "uploadData": "데이터 업로드",
+    "dataFormats": "Excel (.xlsx, .xls), CSV, TSV (최대 500MB)",
+    "dataUploadHint": "정형 테이블은 질의 가능한 데이터셋으로 저장됩니다. 각 시트는 정돈된 표여야 합니다. 병합된 셀, 이미지/차트, 여러 줄 헤더가 있으면 처리되지 않으니 표 형태로 정리 후 다시 업로드하세요.",
     "webUrl": "URL",
     "webUrlPlaceholder": "https://example.com/page",
     "webInstruction": "지시사항",
@@ -130,6 +135,22 @@
     "maxPageHint": "업로드한 문서 중 최대 {{pages}}페이지가 포함되어 있습니다. 공식 지원은 3,000페이지까지이며, PoC에서는 소규모 문서로 먼저 검증하시는 것을 권장합니다.",
     "transcribe": "Transcribe",
     "transcribeDesc": "Amazon Transcribe"
+  },
+  "dataset": {
+    "tab": "데이터",
+    "none": "이 문서에 대한 정형 데이터셋이 없습니다.",
+    "totalRows": "{{count}}행",
+    "queryPlaceholder": "SELECT * FROM data WHERE ... (읽기 전용)",
+    "run": "실행",
+    "clear": "초기화",
+    "queryFailed": "쿼리 실패",
+    "noRows": "행 없음",
+    "queryTruncated": "결과가 잘렸습니다. 전체 결과는 LIMIT이나 집계를 사용하세요.",
+    "sqlEditor": "SQL (읽기 전용, 테이블명: data)",
+    "runHint": "Cmd/Ctrl+Enter로 실행",
+    "reset": "초기화",
+    "columns": "컬럼",
+    "description": "설명"
   },
   "workflow": {
     "title": "워크플로우",
@@ -197,7 +218,8 @@
       "buildingSegments": "세그먼트 구성",
       "segmentAiAnalysis": "AI 분석",
       "graphBuilder": "지식 그래프 구축",
-      "documentSummary": "문서 요약"
+      "documentSummary": "문서 요약",
+      "datasetProcess": "데이터 처리"
     },
     "inProgress": "처리 중...",
     "qaRegenInProgress": "추가 분석 중 (페이지 {{page}})",

--- a/packages/frontend/src/lib/fileTypeUtils.ts
+++ b/packages/frontend/src/lib/fileTypeUtils.ts
@@ -41,6 +41,7 @@ export const isSpreadsheetFileType = (
   if (!fileType) return false;
   return [
     'text/csv',
+    'text/tab-separated-values',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     'application/vnd.ms-excel',
   ].includes(fileType);

--- a/packages/frontend/src/types/project.ts
+++ b/packages/frontend/src/types/project.ts
@@ -159,16 +159,29 @@ export interface ChatSession {
 }
 
 export interface StepStatus {
-  status: 'pending' | 'in_progress' | 'completed' | 'failed' | 'skipped';
+  status:
+    | 'pending'
+    | 'in_progress'
+    | 'completed'
+    | 'failed'
+    | 'skipped'
+    | 'needs_user_fix';
   label: string;
   error?: string;
+  reason?: string;
 }
 
 export interface WorkflowProgress {
   workflowId: string;
   documentId: string;
   fileName: string;
-  status: 'pending' | 'in_progress' | 'reanalyzing' | 'completed' | 'failed';
+  status:
+    | 'pending'
+    | 'in_progress'
+    | 'reanalyzing'
+    | 'completed'
+    | 'failed'
+    | 'needs_user_fix';
   currentStep: string;
   stepMessage: string;
   segmentProgress: { completed: number; total: number } | null;

--- a/packages/infra/cdk.context.json
+++ b/packages/infra/cdk.context.json
@@ -72,5 +72,11 @@
   },
   "ssm:account=975050239358:parameterName=/idp-v2/external-service/unsplash/access-key:region=us-east-1": "AQICAHjvpRYmQcrvdRTn3mwV3OwFuMU3vaMSfGfyxortkukSkQF2HdMx+zEp1iVs3Ysrm5imAAAAijCBhwYJKoZIhvcNAQcGoHoweAIBADBzBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDDL5T9YFTU3CoZbtIAIBEIBGnIyoE/b8Xq8A3e2831SAObmnuI0qzvT2IDYut/mqUlCD0QjI1jAWMgJTPuEwx0ABlE6pgffmGgdkXUaWS84N+L7gipHycg==",
   "ssm:account=975050239358:parameterName=/idp-v2/neptune/cluster-endpoint:region=us-east-1": "idp-v2-neptune.cluster-cpmamkoygyah.us-east-1.neptune.amazonaws.com",
-  "ssm:account=975050239358:parameterName=/idp-v2/neptune/cluster-port:region=us-east-1": "8182"
+  "ssm:account=975050239358:parameterName=/idp-v2/neptune/cluster-port:region=us-east-1": "8182",
+  "availability-zones:account=975050239358:region=us-west-2": [
+    "us-west-2a",
+    "us-west-2b",
+    "us-west-2c",
+    "us-west-2d"
+  ]
 }

--- a/packages/infra/src/functions/preprocessing/type-detection/index.py
+++ b/packages/infra/src/functions/preprocessing/type-detection/index.py
@@ -44,6 +44,7 @@ MIME_TYPE_MAP = {
     'txt': 'text/plain',
     'md': 'text/markdown',
     'csv': 'text/csv',
+    'tsv': 'text/tab-separated-values',
     # Spreadsheets
     'xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     'xls': 'application/vnd.ms-excel',
@@ -224,10 +225,21 @@ def send_to_workflow_queue(
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         'application/vnd.ms-excel',
         'text/csv',
+        'text/tab-separated-values',
     )
     is_dxf = file_type in ('application/dxf', 'image/vnd.dxf')
 
-    processing_type = 'web' if is_webreq else ('text' if (is_text or is_spreadsheet or is_dxf) else get_processing_type(file_type))
+    # Spreadsheets (xlsx/xls/csv) are treated as structured datasets: they take a
+    # separate Step Functions branch (validate -> parquet -> reference doc ->
+    # DATASET#) instead of the document analysis pipeline.
+    if is_spreadsheet:
+        processing_type = 'dataset'
+    elif is_webreq:
+        processing_type = 'web'
+    elif is_text or is_dxf:
+        processing_type = 'text'
+    else:
+        processing_type = get_processing_type(file_type)
 
     # Resolve OCR language option
     resolved_ocr_options = dict(ocr_options or {})

--- a/packages/infra/src/functions/shared/ddb_client.py
+++ b/packages/infra/src/functions/shared/ddb_client.py
@@ -70,6 +70,8 @@ class WorkflowStatus:
     COMPLETED = 'completed'
     FAILED = 'failed'
     SKIPPED = 'skipped'
+    # Structured dataset failed validation; the user must clean the file and re-upload.
+    NEEDS_USER_FIX = 'needs_user_fix'
 
 
 class PreprocessStatus:
@@ -175,6 +177,7 @@ class StepName:
     SEGMENT_ANALYZER = 'segment_analyzer'
     GRAPH_BUILDER = 'graph_builder'
     DOCUMENT_SUMMARIZER = 'document_summarizer'
+    DATASET_PROCESS = 'dataset_process'
 
     ORDER = [
         'segment_prep',
@@ -200,6 +203,7 @@ class StepName:
         'segment_analyzer': 'Segment Analysis',
         'graph_builder': 'Building Knowledge Graph',
         'document_summarizer': 'Document Summary',
+        'dataset_process': 'Dataset Processing',
     }
 
 
@@ -269,32 +273,53 @@ def create_workflow(
         'application/dxf',
         'image/vnd.dxf',
     )
+    # Structured datasets (xlsx/xls/csv/tsv) take the dataset_process branch and
+    # skip the entire document-analysis pipeline.
+    is_dataset = file_type in (
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.ms-excel',
+        'text/csv',
+        'text/tab-separated-values',
+    )
 
-    skip_conditions = {
-        StepName.BDA_PROCESSOR: not use_bda or is_webreq,
-        StepName.PADDLEOCR_PROCESSOR: not (is_pdf or is_image)
-        or is_webreq
-        or not use_ocr,
-        StepName.TRANSCRIBE: not (is_video or is_audio)
-        or is_webreq
-        or not use_transcribe,
-        StepName.FORMAT_PARSER: not (is_pdf or is_dxf_file) or is_webreq,
-        StepName.WEBCRAWLER: not is_webreq,
-        StepName.SEGMENT_ANALYZER: False,
-    }
-
-    # Initialize STEP row with appropriate statuses
     steps_data = {
         'project_id': project_id,
         'document_id': document_id,
         'current_step': '',
     }
-    for step_name in StepName.ORDER:
-        should_skip = skip_conditions.get(step_name, False)
-        steps_data[step_name] = {
-            'status': WorkflowStatus.SKIPPED if should_skip else WorkflowStatus.PENDING,
-            'label': StepName.LABELS.get(step_name, step_name),
+
+    if is_dataset:
+        # Only dataset_process runs; all document-analysis steps are skipped.
+        for step_name in StepName.ORDER:
+            steps_data[step_name] = {
+                'status': WorkflowStatus.SKIPPED,
+                'label': StepName.LABELS.get(step_name, step_name),
+            }
+        steps_data[StepName.DATASET_PROCESS] = {
+            'status': WorkflowStatus.PENDING,
+            'label': StepName.LABELS.get(StepName.DATASET_PROCESS, 'Dataset Processing'),
         }
+    else:
+        skip_conditions = {
+            StepName.BDA_PROCESSOR: not use_bda or is_webreq,
+            StepName.PADDLEOCR_PROCESSOR: not (is_pdf or is_image)
+            or is_webreq
+            or not use_ocr,
+            StepName.TRANSCRIBE: not (is_video or is_audio)
+            or is_webreq
+            or not use_transcribe,
+            StepName.FORMAT_PARSER: not (is_pdf or is_dxf_file) or is_webreq,
+            StepName.WEBCRAWLER: not is_webreq,
+            StepName.SEGMENT_ANALYZER: False,
+        }
+        for step_name in StepName.ORDER:
+            should_skip = skip_conditions.get(step_name, False)
+            steps_data[step_name] = {
+                'status': WorkflowStatus.SKIPPED
+                if should_skip
+                else WorkflowStatus.PENDING,
+                'label': StepName.LABELS.get(step_name, step_name),
+            }
 
     steps_item = {
         'PK': f'WF#{workflow_id}',
@@ -529,6 +554,7 @@ def record_step_start(workflow_id: str, step_name: str, **kwargs) -> dict:
     step_data = data.get(step_name, {})
     step_data['status'] = WorkflowStatus.IN_PROGRESS
     step_data['started_at'] = now
+    step_data.setdefault('label', StepName.LABELS.get(step_name, step_name))
     for key, value in kwargs.items():
         step_data[key] = value
     data[step_name] = step_data
@@ -653,6 +679,73 @@ def record_step_skipped(workflow_id: str, step_name: str, reason: str = '') -> d
         ReturnValues='ALL_NEW',
     )
     return decimal_to_python(response.get('Attributes', {}))
+
+
+def record_step_needs_fix(workflow_id: str, step_name: str, reason: str, details: dict | None = None) -> dict:
+    """Update step status to needs_user_fix (structured dataset failed validation)."""
+    table = get_table()
+    now = now_iso()
+
+    steps = get_steps(workflow_id)
+    if not steps:
+        return {}
+
+    data = steps.get('data', {})
+    step_data = data.get(step_name, {})
+    step_data['status'] = WorkflowStatus.NEEDS_USER_FIX
+    step_data['reason'] = reason
+    if details:
+        step_data['details'] = details
+    data[step_name] = step_data
+    data['current_step'] = ''
+
+    response = table.update_item(
+        Key={'PK': f'WF#{workflow_id}', 'SK': 'STEP'},
+        UpdateExpression='SET #data = :data, updated_at = :updated_at',
+        ExpressionAttributeNames={'#data': 'data'},
+        ExpressionAttributeValues={':data': data, ':updated_at': now},
+        ReturnValues='ALL_NEW',
+    )
+    return decimal_to_python(response.get('Attributes', {}))
+
+
+def save_dataset(
+    project_id: str,
+    dataset_id: str,
+    name: str,
+    dataset_s3_uri: str,
+    reference_s3_uri: str = '',
+    description: str = '',
+    row_count: int | None = None,
+    columns: list | None = None,
+    source_document_id: str = '',
+) -> dict:
+    """Save a structured dataset (Parquet) reference as PROJ#/DATASET# for Text2SQL.
+
+    Schema matches backend app/ddb/datasets.py (DatasetData).
+    """
+    table = get_table()
+    now = now_iso()
+
+    item = {
+        'PK': f'PROJ#{project_id}',
+        'SK': f'DATASET#{dataset_id}',
+        'data': {
+            'dataset_id': dataset_id,
+            'project_id': project_id,
+            'name': name,
+            'description': description,
+            'dataset_s3_uri': dataset_s3_uri,
+            'reference_s3_uri': reference_s3_uri or None,
+            'row_count': row_count,
+            'columns': columns,
+            'source_document_id': source_document_id or None,
+        },
+        'created_at': now,
+        'updated_at': now,
+    }
+    table.put_item(Item=item)
+    return decimal_to_python(item)
 
 
 def save_segment(

--- a/packages/infra/src/functions/step-functions/dataset-process/Dockerfile
+++ b/packages/infra/src/functions/step-functions/dataset-process/Dockerfile
@@ -1,0 +1,23 @@
+FROM public.ecr.aws/docker/library/python:3.13-slim
+
+# DuckDB writes its home/extensions under HOME; Lambda only allows /tmp.
+ENV HOME=/tmp
+
+# Lambda Runtime Interface Client
+RUN pip install --no-cache-dir awslambdaric
+
+WORKDIR /var/task
+
+COPY step-functions/dataset-process/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Shared modules (ddb_client, etc.)
+COPY shared/ ./shared/
+
+# Handler + helpers
+COPY step-functions/dataset-process/index.py .
+COPY step-functions/dataset-process/validator.py .
+COPY step-functions/dataset-process/reference.py .
+
+ENTRYPOINT ["python", "-m", "awslambdaric"]
+CMD ["index.handler"]

--- a/packages/infra/src/functions/step-functions/dataset-process/index.py
+++ b/packages/infra/src/functions/step-functions/dataset-process/index.py
@@ -1,0 +1,376 @@
+"""DatasetProcess Lambda: xlsx/csv -> validate -> parquet -> reference doc -> DATASET#.
+
+Single Step Functions step for the structured-data branch. Runs the whole
+pipeline in one Lambda (no inter-step S3 round trips). Each sheet becomes its own
+dataset. Identifiers/paths are document_id-based ASCII (Korean file/sheet names
+live only in the DATASET# `name`).
+
+Input (from Step Functions):
+  { workflow_id, document_id, project_id, file_uri, file_name, file_type }
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import boto3
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+# Heavy libraries (duckdb, pandas, pyarrow, openpyxl, strands via reference) are
+# imported lazily inside the handler. Lambda's init phase has a hard ~10s limit
+# and these imports exceed it; deferring them to the handler (15 min budget)
+# avoids the init timeout / re-init on cold start.
+from shared.ddb_client import (
+    StepName,
+    WorkflowStatus,
+    get_document,
+    get_entity_prefix,
+    record_step_complete,
+    record_step_needs_fix,
+    record_step_start,
+    save_dataset,
+    update_workflow_status,
+)
+from validator import validate_workbook
+
+_s3 = boto3.client("s3")
+_lambda = boto3.client("lambda")
+
+LANCEDB_FUNCTION_NAME = os.environ.get("LANCEDB_FUNCTION_NAME", "idp-v2-lance-service")
+
+
+def _parse_s3_uri(uri: str) -> tuple[str, str]:
+    p = urlparse(uri)
+    return p.netloc, p.path.lstrip("/")
+
+
+def _index_dataset_catalog(
+    project_id: str,
+    dataset_id: str,
+    dataset_s3_uri: str,
+    name: str,
+    description: str,
+    columns: list[str],
+    row_count: int,
+) -> None:
+    """Index a dataset into the per-project catalog (LanceDB) for search_datasets.
+
+    Best-effort: a catalog failure must not fail dataset creation, since the
+    dataset itself (DATASET# + Parquet) is already usable.
+    """
+    try:
+        resp = _lambda.invoke(
+            FunctionName=LANCEDB_FUNCTION_NAME,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(
+                {
+                    "action": "add_dataset",
+                    "params": {
+                        "project_id": project_id,
+                        "dataset_id": dataset_id,
+                        "dataset_s3_uri": dataset_s3_uri,
+                        "name": name,
+                        "description": description,
+                        "columns": columns,
+                        "row_count": row_count,
+                    },
+                }
+            ),
+        )
+        if "FunctionError" in resp:
+            print(
+                f"Dataset catalog indexing error for {dataset_id}: "
+                f"{resp['Payload'].read().decode('utf-8')}"
+            )
+    except Exception as e:  # noqa: BLE001 - catalog is best-effort
+        print(f"Dataset catalog indexing failed for {dataset_id}: {e}")
+
+
+def _snake_case(name: str) -> str:
+    """Normalize a column name to a safe snake_case SQL identifier.
+
+    Makes columns queryable without double-quoting (e.g. 'Primary Type' ->
+    'primary_type', 'Sp.Atk' -> 'sp_atk', '#' -> 'col'). Handles camelCase,
+    spaces, punctuation, and leading digits.
+    """
+    s = str(name).strip()
+    # Split camelCase / PascalCase boundaries: "fooBar" -> "foo Bar".
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", s)
+    s = s.lower()
+    # Any run of non-alphanumeric characters becomes a single underscore.
+    s = re.sub(r"[^a-z0-9]+", "_", s).strip("_")
+    # Identifiers cannot start with a digit.
+    if s and s[0].isdigit():
+        s = f"c_{s}"
+    return s or "col"
+
+
+def _snake_case_columns(df: "pd.DataFrame") -> "pd.DataFrame":
+    """Rename all DataFrame columns to unique snake_case identifiers.
+
+    On collision (e.g. 'Sp.Atk' and 'Sp Atk' both -> 'sp_atk', or a source that
+    already contains 'valid_from' and 'Valid from.1'), a numeric suffix is
+    appended. The suffixed name is also checked against every name already taken,
+    so a generated name (e.g. 'valid_from_1') can never collide with a later
+    source column that normalizes to the same string.
+    """
+    used: set[str] = set()
+    new_cols = []
+    for col in df.columns:
+        base = _snake_case(col)
+        candidate = base
+        i = 0
+        while candidate in used:
+            i += 1
+            candidate = f"{base}_{i}"
+        used.add(candidate)
+        new_cols.append(candidate)
+    df.columns = new_cols
+    return df
+
+
+def _output_dir(document_key: str) -> str:
+    """Directory to write parquet/reference into: a `dataset/` subfolder under the
+    original document's folder.
+
+    e.g. projects/{pid}/documents/{doc_id}/{doc_id}.xlsx
+      -> projects/{pid}/documents/{doc_id}/dataset
+
+    The `dataset/` subfolder is deliberate: the S3-upload EventBridge rule excludes
+    keys matching `projects/*/documents/*/*/*` (6+ segments), so outputs written one
+    level below documents/{doc_id}/ (like analysis/, bda-output/) never re-trigger
+    the workflow. Writing directly to documents/{doc_id}/{doc_id}.parquet (5 segments,
+    same depth as the original upload) WOULD re-trigger it.
+    """
+    return document_key.rsplit("/", 1)[0] + "/dataset"
+
+
+def handler(event: dict, context) -> dict:
+    workflow_id = event["workflow_id"]
+    document_id = event["document_id"]
+    project_id = event["project_id"]
+    file_uri = event["file_uri"]
+    file_type = event.get("file_type", "")
+
+    # Prefer the original upload filename (stored on the DOC# item) over the
+    # event's file_name, which is document_id-based (S3 key = {doc_id}.{ext}).
+    # get_document returns the item's `data` dict directly.
+    file_name = event.get("file_name", document_id)
+    doc_data = get_document(project_id, document_id)
+    if doc_data and doc_data.get("name"):
+        file_name = doc_data["name"]
+
+    entity_type = get_entity_prefix(file_type)
+    record_step_start(workflow_id, StepName.DATASET_PROCESS)
+
+    bucket, key = _parse_s3_uri(file_uri)
+    body = _s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+
+    # Delimited text (csv/tsv) vs Excel workbook. TSV is CSV with a tab separator.
+    name_lower = file_name.lower()
+    is_tsv = file_type == "text/tab-separated-values" or name_lower.endswith(".tsv")
+    is_csv = file_type == "text/csv" or name_lower.endswith(".csv")
+    is_xls = file_type == "application/vnd.ms-excel" or name_lower.endswith(".xls")
+    delimiter = "\t" if is_tsv else ("," if is_csv else None)
+
+    # 1) Load sheets as DataFrames + validate.
+    try:
+        sheets, failures = _load_and_validate(body, delimiter, is_xls, file_name)
+    except Exception as e:  # noqa: BLE001 - unreadable file is a user-fix case
+        reason = f"파일을 읽을 수 없습니다: {e}"
+        record_step_needs_fix(workflow_id, StepName.DATASET_PROCESS, reason)
+        update_workflow_status(document_id, workflow_id, WorkflowStatus.NEEDS_USER_FIX, entity_type)
+        return {"workflow_id": workflow_id, "status": WorkflowStatus.NEEDS_USER_FIX, "reason": reason}
+
+    if not sheets:
+        reason = _format_failures(failures)
+        record_step_needs_fix(workflow_id, StepName.DATASET_PROCESS, reason, {"sheets": failures})
+        update_workflow_status(document_id, workflow_id, WorkflowStatus.NEEDS_USER_FIX, entity_type)
+        return {"workflow_id": workflow_id, "status": WorkflowStatus.NEEDS_USER_FIX, "reason": reason}
+
+    # 2) Per valid sheet: parquet -> reference -> DATASET#.
+    # Outputs live alongside the original document under documents/{doc_id}/.
+    out_bucket = bucket
+    out_dir = _output_dir(key)
+    created = []
+    for sheet in sheets:
+        dataset_id = document_id if sheet["single"] else f"{document_id}__{sheet['index']}"
+        parquet_key = f"{out_dir}/{dataset_id}.parquet"
+        reference_key = f"{out_dir}/{dataset_id}.txt"
+        parquet_uri = f"s3://{out_bucket}/{parquet_key}"
+        reference_uri = f"s3://{out_bucket}/{reference_key}"
+
+        # Normalize columns to snake_case so SQL can reference them without
+        # double-quoting (e.g. "Primary Type" -> primary_type). Applied here,
+        # after validation, so both the Parquet and the reference doc/DDB use
+        # the same normalized names.
+        df = _snake_case_columns(sheet["df"])
+
+        # parquet -> S3
+        buf = io.BytesIO()
+        df.to_parquet(buf, index=False)
+        buf.seek(0)
+        _s3.put_object(Bucket=out_bucket, Key=parquet_key, Body=buf.getvalue())
+
+        # reference doc via DuckDB profiling + Bedrock (lazy imports, see top)
+        import duckdb
+        import pyarrow as pa
+
+        from reference import build_reference
+
+        con = duckdb.connect()
+        con.register("data", pa.Table.from_pandas(df, preserve_index=False))
+        display_name = file_name if sheet["single"] else f"{file_name} / {sheet['name']}"
+        description = ""
+        try:
+            reference, description = build_reference(con, display_name)
+            _s3.put_object(
+                Bucket=out_bucket, Key=reference_key,
+                Body=reference.encode("utf-8"), ContentType="text/plain; charset=utf-8",
+            )
+            ref_uri = reference_uri
+        except Exception as e:  # noqa: BLE001 - reference is best-effort; dataset still usable
+            print(f"Reference generation failed for {dataset_id}: {e}")
+            ref_uri = ""
+        finally:
+            con.close()
+
+        columns = [str(c) for c in df.columns]
+        save_dataset(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            name=display_name,
+            description=description,
+            dataset_s3_uri=parquet_uri,
+            reference_s3_uri=ref_uri,
+            row_count=int(len(df)),
+            columns=columns,
+            source_document_id=document_id,
+        )
+        # Index into the per-project dataset catalog so the agent can find this
+        # dataset by name/description (search_datasets) instead of listing all.
+        _index_dataset_catalog(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            dataset_s3_uri=parquet_uri,
+            name=display_name,
+            description=description,
+            columns=columns,
+            row_count=int(len(df)),
+        )
+        created.append({"dataset_id": dataset_id, "dataset_s3_uri": parquet_uri, "rows": int(len(df))})
+
+    record_step_complete(
+        workflow_id, StepName.DATASET_PROCESS,
+        dataset_count=len(created),
+        skipped_sheets=len(failures),
+    )
+    update_workflow_status(
+        document_id, workflow_id, WorkflowStatus.COMPLETED, entity_type,
+        dataset_count=len(created),
+    )
+    return {
+        "workflow_id": workflow_id,
+        "status": WorkflowStatus.COMPLETED,
+        "datasets": created,
+        "skipped_sheets": failures,
+    }
+
+
+def _load_and_validate(
+    body: bytes, delimiter: str | None, is_xls: bool, file_name: str
+):
+    """Return (valid_sheets, failures). valid_sheets carry the DataFrame to write.
+
+    delimiter is set for delimited text (',' for CSV, '\\t' for TSV); None for Excel.
+    is_xls marks the legacy .xls format (openpyxl can't read it -> use xlrd).
+    """
+    import pandas as pd
+
+    if delimiter is not None:
+        df = pd.read_csv(io.BytesIO(body), sep=delimiter)
+        reasons = _validate_dataframe(df)
+        if reasons:
+            return [], [{"sheet_name": file_name, "sheet_index": 0, "reasons": reasons}]
+        return [{"df": df, "name": file_name, "index": 0, "single": True}], []
+
+    if is_xls:
+        # Legacy .xls: openpyxl can't open BIFF, so read every sheet with pandas
+        # (xlrd engine) and validate the resulting DataFrames. Structural checks
+        # (merged cells / images) are not available for this format.
+        book = pd.read_excel(io.BytesIO(body), sheet_name=None, engine="xlrd")
+        names = list(book.keys())
+        sheets = []
+        failures = []
+        for idx, name in enumerate(names):
+            df = book[name]
+            reasons = _validate_dataframe(df)
+            if reasons:
+                failures.append(
+                    {"sheet_name": name, "sheet_index": idx, "reasons": reasons}
+                )
+            else:
+                sheets.append({"df": df, "name": name, "index": idx, "single": False})
+        if not sheets:
+            return [], failures
+        if len(sheets) == 1 and len(names) == 1:
+            sheets[0]["single"] = True
+        return sheets, failures
+
+    # Excel (.xlsx): validate structure with openpyxl, then read valid sheets.
+    # NOTE: read_only=True omits merged_cells/_images/_charts, which the validator
+    # needs, so load in normal mode.
+    import openpyxl
+
+    wb = openpyxl.load_workbook(io.BytesIO(body), data_only=True)
+    validations = validate_workbook(wb)
+    wb.close()
+
+    valid = [v for v in validations if v.ok]
+    failures = [
+        {"sheet_name": v.sheet_name, "sheet_index": v.sheet_index, "reasons": v.reasons}
+        for v in validations
+        if not v.ok
+    ]
+    if not valid:
+        return [], failures
+
+    single = len(valid) == 1 and len(validations) == 1
+    sheets = []
+    for v in valid:
+        df = pd.read_excel(io.BytesIO(body), sheet_name=v.sheet_name)
+        sheets.append({"df": df, "name": v.sheet_name, "index": v.sheet_index, "single": single})
+    return sheets, failures
+
+
+def _validate_dataframe(df: pd.DataFrame) -> list[str]:
+    """Lightweight validation for CSV (openpyxl checks cover Excel).
+
+    Duplicate column names are not rejected: snake_case normalization makes them
+    unique automatically (see _snake_case_columns).
+    """
+    reasons = []
+    if df.empty:
+        reasons.append("데이터 행이 없습니다.")
+    cols = [str(c) for c in df.columns]
+    if any(c.startswith("Unnamed:") or c.strip() == "" for c in cols):
+        reasons.append("빈 헤더 열이 있습니다.")
+    return reasons
+
+
+def _format_failures(failures: list[dict]) -> str:
+    parts = []
+    for f in failures:
+        parts.append(f"[{f['sheet_name']}] " + " ".join(f["reasons"]))
+    joined = " / ".join(parts) if parts else "정형 데이터로 처리할 수 없습니다."
+    return (
+        "정형 데이터로 처리할 수 없습니다. 표 형태로 정리 후 다시 업로드하세요. "
+        + joined
+    )

--- a/packages/infra/src/functions/step-functions/dataset-process/reference.py
+++ b/packages/infra/src/functions/step-functions/dataset-process/reference.py
@@ -1,0 +1,118 @@
+"""Generate a Text2SQL reference document for a Parquet dataset.
+
+Ports the notebook's parquet_agent approach: profile the table with DuckDB
+(schema + SUMMARIZE + sample rows) and let Bedrock write a Markdown reference
+(table overview, column dictionary, query patterns, caveats). This document is
+what describe_dataset returns and is the source of truth for run_sql.
+"""
+
+import os
+import re
+
+import duckdb
+from strands import Agent
+from strands.models import BedrockModel
+
+REFERENCE_MODEL_ID = os.environ.get(
+    "DATASET_REFERENCE_MODEL_ID", "global.anthropic.claude-sonnet-5"
+)
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+SYSTEM_PROMPT = """You are a Parquet schema analyst. Produce (1) a short standalone
+description and (2) a reference document that a text2SQL agent uses to translate
+natural-language questions into correct DuckDB SQL.
+
+The dataset is exposed as the table `data`. You are GIVEN the schema, full-column
+statistics (SUMMARIZE), and sample rows below — do NOT ask for more; write the output.
+
+Respond in EXACTLY this format:
+
+<description>
+A self-contained description (3-6 sentences) of what this dataset contains: the
+subject/domain, what each row represents, the key columns and what they mean, the
+row count / scale, and any notable characteristics (hierarchy, categories, time
+range, etc.). This is shown in a dataset picker so an agent can decide, WITHOUT
+opening the full document, whether this dataset answers a question. Write it in the
+same language as the data's textual values when they are non-English.
+</description>
+
+Then a structured Markdown reference document with these sections:
+
+### 1. Table Overview
+What this dataset represents.
+
+### 2. Column Dictionary
+| Column | Type | Description | Example Values | Notes |
+
+### 3. Key Relationships & Business Logic
+Implicit meaning, derived columns, enum semantics.
+
+### 4. Common Query Patterns
+A few natural-language questions and their DuckDB SQL (use `data` as the table name;
+double-quote column names that contain spaces or special characters).
+
+### 5. Caveats
+NULL handling, non-unique keys, data-quality anomalies, columns needing quoting.
+
+Keep descriptions concise but unambiguous for an LLM consumer.
+"""
+
+_DESCRIPTION_RE = re.compile(r"<description>\s*(.*?)\s*</description>", re.DOTALL | re.IGNORECASE)
+
+
+def build_reference(con: duckdb.DuckDBPyConnection, dataset_name: str) -> tuple[str, str]:
+    """Profile the 'data' table and generate (reference_markdown, description).
+
+    A single Bedrock call returns both a standalone description (for the dataset
+    list) and the full reference document (for describe_dataset).
+    """
+    schema = con.execute("DESCRIBE data").fetchall()
+    summarize = con.execute("SUMMARIZE data").fetchall()
+    summarize_cols = [d[0] for d in con.execute("SUMMARIZE data").description]
+    sample = con.execute("SELECT * FROM data LIMIT 5").fetchall()
+    sample_cols = [d[0] for d in con.execute("SELECT * FROM data LIMIT 5").description]
+    row_count = con.execute("SELECT COUNT(*) FROM data").fetchone()[0]
+
+    profile = _format_profile(
+        dataset_name, row_count, schema, summarize_cols, summarize, sample_cols, sample
+    )
+
+    model = BedrockModel(model_id=REFERENCE_MODEL_ID, region_name=AWS_REGION)
+    agent = Agent(model=model, system_prompt=SYSTEM_PROMPT)
+    output = str(agent(profile))
+
+    # Split the <description> block from the reference document.
+    match = _DESCRIPTION_RE.search(output)
+    if match:
+        description = match.group(1).strip()
+        reference = _DESCRIPTION_RE.sub("", output, count=1).strip()
+    else:
+        description = ""
+        reference = output.strip()
+    return reference, description
+
+
+def _format_profile(name, row_count, schema, sum_cols, summarize, sample_cols, sample) -> str:
+    lines = [
+        f"Dataset name: {name}",
+        "Table name to use in SQL: data",
+        f"Row count: {row_count}",
+        "",
+        "## Schema (column, type)",
+    ]
+    for col in schema:
+        lines.append(f"- {col[0]}: {col[1]}")
+
+    lines.append("")
+    lines.append("## SUMMARIZE (per-column statistics)")
+    lines.append(" | ".join(sum_cols))
+    for row in summarize:
+        lines.append(" | ".join("" if v is None else str(v) for v in row))
+
+    lines.append("")
+    lines.append("## Sample rows")
+    lines.append(" | ".join(sample_cols))
+    for row in sample:
+        lines.append(" | ".join("" if v is None else str(v) for v in row))
+
+    return "\n".join(lines)

--- a/packages/infra/src/functions/step-functions/dataset-process/requirements.txt
+++ b/packages/infra/src/functions/step-functions/dataset-process/requirements.txt
@@ -1,0 +1,8 @@
+boto3
+pandas>=2.0
+pyarrow
+openpyxl
+xlrd
+duckdb
+strands-agents>=1.25
+pyyaml

--- a/packages/infra/src/functions/step-functions/dataset-process/validator.py
+++ b/packages/infra/src/functions/step-functions/dataset-process/validator.py
@@ -1,0 +1,71 @@
+"""Structured-dataset validation.
+
+The quality gate is the INPUT data, not an LLM-generated document: a spreadsheet
+must be a clean tabular table to become a queryable dataset. Non-tabular content
+(merged cells, images/charts, multi-row headers, duplicate/empty columns) is
+rejected so the user cleans and re-uploads.
+
+Each sheet is validated independently. A sheet that passes is converted to its own
+dataset; sheets that fail are reported. If NO sheet passes, the whole step is
+NEEDS_USER_FIX.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SheetValidation:
+    sheet_name: str
+    sheet_index: int
+    ok: bool
+    reasons: list[str] = field(default_factory=list)
+
+
+def validate_workbook(wb) -> list[SheetValidation]:
+    """Validate every sheet in an openpyxl workbook. Returns per-sheet results."""
+    results: list[SheetValidation] = []
+    for idx, ws in enumerate(wb.worksheets):
+        reasons: list[str] = []
+
+        # Images / charts / drawings: reject (not tabular data).
+        if getattr(ws, "_images", None):
+            reasons.append("시트에 이미지가 포함되어 있습니다.")
+        if getattr(ws, "_charts", None):
+            reasons.append("시트에 차트가 포함되어 있습니다.")
+
+        # Merged cells break the row/column grid.
+        merged = getattr(ws, "merged_cells", None)
+        if merged is not None and getattr(merged, "ranges", None):
+            reasons.append("병합된 셀이 있어 표 구조가 깨집니다.")
+
+        # Header (first row) checks: needs a non-empty header row. Duplicate
+        # column names are NOT rejected: the parquet step normalizes columns to
+        # unique snake_case (e.g. material, material_1), so duplicates are handled
+        # automatically rather than being a user-fix case.
+        header = _first_row_values(ws)
+        if not header:
+            reasons.append("헤더(첫 행)가 비어 있습니다.")
+        else:
+            empty = [i for i, v in enumerate(header) if v is None or str(v).strip() == ""]
+            if empty:
+                reasons.append("빈 헤더 열이 있습니다.")
+
+        # Needs at least one data row beyond the header.
+        if ws.max_row is not None and ws.max_row < 2:
+            reasons.append("데이터 행이 없습니다(헤더만 존재).")
+
+        results.append(
+            SheetValidation(
+                sheet_name=ws.title,
+                sheet_index=idx,
+                ok=len(reasons) == 0,
+                reasons=reasons,
+            )
+        )
+    return results
+
+
+def _first_row_values(ws) -> list:
+    for row in ws.iter_rows(min_row=1, max_row=1, values_only=True):
+        return list(row)
+    return []

--- a/packages/infra/src/prompts/chat/system_prompt.txt
+++ b/packages/infra/src/prompts/chat/system_prompt.txt
@@ -45,6 +45,32 @@ Execute the plan step by step:
 - Cite sources when applicable.
 - If the task produced an artifact, report the artifact reference.
 
+## Structured vs. Unstructured Data
+
+You can query two kinds of data. Choose based on the question:
+
+- **Unstructured documents** (brochures, manuals, specs) — use the document search tools.
+  Best for descriptions, features, explanations, and "how/why" questions.
+- **Structured datasets** (Parquet tables: spec sheets, catalogs, spreadsheets) — use the
+  data tools (`search_datasets`, `describe_dataset`, `run_sql`). Best for exact numbers,
+  aggregation, filtering, ranking, and counting ("how many", "top 5", "average of ...").
+
+### Using structured data tools (Text2SQL)
+1. Call `search_datasets` with a description of the data you need to find relevant datasets (projects may have many).
+2. Call `describe_dataset` to learn its columns, types, and enum values BEFORE writing SQL.
+   The reference document is the source of truth — do NOT invent column names or values.
+3. Call `run_sql` with a read-only DuckDB query. The dataset is exposed as the table `data`
+   (always query `FROM data`). Only SELECT/WITH is allowed.
+4. Base the answer only on query results; show the SQL you used in a code block.
+
+### Cross questions (span both)
+When a question needs BOTH (e.g. "the gaming OLED TV — tell me its price and specs"):
+1. First search the documents to identify the product/entity and gather context.
+2. Then query the structured dataset using the name/keywords you found. Names may not match
+   exactly — use the document context to pick the right row.
+3. Synthesize both into one answer. Do NOT pre-assume the two sources are linked; connect
+   them at query time using the context, and cite each source.
+
 ## Response Guidelines
 
 ### Formatting

--- a/packages/infra/src/stacks/mcp-stack.ts
+++ b/packages/infra/src/stacks/mcp-stack.ts
@@ -8,6 +8,7 @@ import {
   SearchMcp,
   ImageMcp,
   QaMcp,
+  DataMcp,
   SSM_KEYS,
 } from ':idp-v2/common-constructs';
 import * as agentcore from '@aws-cdk/aws-bedrock-agentcore-alpha';
@@ -16,6 +17,7 @@ import * as path from 'path';
 export class McpStack extends Stack {
   public readonly searchMcp: SearchMcp;
   public readonly qaMcp: QaMcp;
+  public readonly dataMcp: DataMcp;
   public readonly imageMcp?: ImageMcp;
   public readonly gateway: agentcore.Gateway;
 
@@ -76,6 +78,23 @@ export class McpStack extends Stack {
     });
     this.qaMcp.function.grantInvoke(this.gateway.role);
     qaTarget.node.addDependency(this.gateway.role);
+
+    this.dataMcp = new DataMcp(this, 'DataMcp');
+
+    const dataTarget = this.gateway.addLambdaTarget('DataMcpTarget', {
+      gatewayTargetName: 'data',
+      description:
+        'Structured data (Text2SQL): list datasets, read a dataset reference doc, and run read-only SQL over a project Parquet dataset. Use for exact aggregation, filtering, ranking, and counting over tables.',
+      lambdaFunction: this.dataMcp.function,
+      toolSchema: agentcore.ToolSchema.fromLocalAsset(
+        path.resolve(
+          process.cwd(),
+          '../../packages/lambda/data-mcp/schema.json',
+        ),
+      ),
+    });
+    this.dataMcp.function.grantInvoke(this.gateway.role);
+    dataTarget.node.addDependency(this.gateway.role);
 
     // Web Search built-in connector target. The AgentCore Web Search connector
     // is not yet supported by the CDK L2/L1 target APIs, so it is created via a

--- a/packages/infra/src/stacks/workflow-stack.ts
+++ b/packages/infra/src/stacks/workflow-stack.ts
@@ -416,6 +416,40 @@ export class WorkflowStack extends Stack {
       environment: { ...commonLambdaProps.environment },
     });
 
+    // Dataset Process (structured data branch): validate xlsx/csv, convert each
+    // sheet to Parquet, generate a Text2SQL reference doc (Bedrock), record DATASET#.
+    // Docker Lambda for pandas/pyarrow/duckdb/openpyxl + strands.
+    const datasetProcess = new lambda.DockerImageFunction(this, 'DatasetProcess', {
+      functionName: 'idp-v2-dataset-process',
+      code: lambda.DockerImageCode.fromImageAsset(
+        path.join(__dirname, '../functions'),
+        {
+          file: 'step-functions/dataset-process/Dockerfile',
+          platform: Platform.LINUX_ARM64,
+        },
+      ),
+      architecture: lambda.Architecture.ARM_64,
+      timeout: Duration.minutes(15),
+      // Higher memory => more CPU, which speeds up the heavy imports (pandas,
+      // pyarrow, duckdb, strands) and Parquet conversion.
+      memorySize: 3008,
+      ephemeralStorageSize: Size.gibibytes(2),
+      environment: {
+        ...commonLambdaProps.environment,
+        DATASET_REFERENCE_MODEL_ID: models.analysis,
+        // Index each dataset into the per-project catalog (search_datasets).
+        LANCEDB_FUNCTION_NAME: lancedbService.functionName,
+      },
+    });
+    // S3 (doc bucket) + DDB grants come from the allFunctions loop below.
+    datasetProcess.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+        resources: ['*'],
+      }),
+    );
+    lancedbService.grantInvoke(datasetProcess);
+
     // Check analysis throttle (called after preprocessing completes)
     const checkPreprocessStatus = new lambda.Function(
       this,
@@ -1609,7 +1643,29 @@ export class WorkflowStack extends Stack {
       )
       .otherwise(parallelPreprocessing);
 
-    const definition = isReanalysisChoice;
+    // Structured dataset branch: xlsx/csv skip the document analysis pipeline and
+    // run validate -> parquet -> reference -> DATASET# in a single Lambda, which
+    // also finalizes the workflow status.
+    const datasetProcessTask = new tasks.LambdaInvoke(this, 'ProcessDataset', {
+      lambdaFunction: datasetProcess,
+      outputPath: '$.Payload',
+      comment:
+        'Validate a spreadsheet, convert each valid sheet to Parquet, generate a Text2SQL reference doc, and record DATASET#. Sets workflow status to completed or needs_user_fix.',
+    });
+    datasetProcessTask.addCatch(errorHandlerTask, catchConfig);
+
+    // Entry Choice: route structured datasets before the document pipeline.
+    const isDatasetChoice = new sfn.Choice(this, 'IsDataset', {
+      comment:
+        "Entry point: if processing_type='dataset' (xlsx/csv), run the structured dataset branch; otherwise fall through to the document pipeline.",
+    })
+      .when(
+        sfn.Condition.stringEquals('$.processing_type', 'dataset'),
+        datasetProcessTask,
+      )
+      .otherwise(isReanalysisChoice);
+
+    const definition = isDatasetChoice;
 
     this.stateMachine = new sfn.StateMachine(
       this,
@@ -1701,6 +1757,7 @@ export class WorkflowStack extends Stack {
       segmentPrep,
       segmentPrepFinalizer,
       formatParser,
+      datasetProcess,
       checkPreprocessStatus,
       segmentBuilder,
       reanalysisPrep,

--- a/packages/infra/src/stacks/workflow-stack.ts
+++ b/packages/infra/src/stacks/workflow-stack.ts
@@ -419,32 +419,39 @@ export class WorkflowStack extends Stack {
     // Dataset Process (structured data branch): validate xlsx/csv, convert each
     // sheet to Parquet, generate a Text2SQL reference doc (Bedrock), record DATASET#.
     // Docker Lambda for pandas/pyarrow/duckdb/openpyxl + strands.
-    const datasetProcess = new lambda.DockerImageFunction(this, 'DatasetProcess', {
-      functionName: 'idp-v2-dataset-process',
-      code: lambda.DockerImageCode.fromImageAsset(
-        path.join(__dirname, '../functions'),
-        {
-          file: 'step-functions/dataset-process/Dockerfile',
-          platform: Platform.LINUX_ARM64,
+    const datasetProcess = new lambda.DockerImageFunction(
+      this,
+      'DatasetProcess',
+      {
+        functionName: 'idp-v2-dataset-process',
+        code: lambda.DockerImageCode.fromImageAsset(
+          path.join(__dirname, '../functions'),
+          {
+            file: 'step-functions/dataset-process/Dockerfile',
+            platform: Platform.LINUX_ARM64,
+          },
+        ),
+        architecture: lambda.Architecture.ARM_64,
+        timeout: Duration.minutes(15),
+        // Higher memory => more CPU, which speeds up the heavy imports (pandas,
+        // pyarrow, duckdb, strands) and Parquet conversion.
+        memorySize: 3008,
+        ephemeralStorageSize: Size.gibibytes(2),
+        environment: {
+          ...commonLambdaProps.environment,
+          DATASET_REFERENCE_MODEL_ID: models.analysis,
+          // Index each dataset into the per-project catalog (search_datasets).
+          LANCEDB_FUNCTION_NAME: lancedbService.functionName,
         },
-      ),
-      architecture: lambda.Architecture.ARM_64,
-      timeout: Duration.minutes(15),
-      // Higher memory => more CPU, which speeds up the heavy imports (pandas,
-      // pyarrow, duckdb, strands) and Parquet conversion.
-      memorySize: 3008,
-      ephemeralStorageSize: Size.gibibytes(2),
-      environment: {
-        ...commonLambdaProps.environment,
-        DATASET_REFERENCE_MODEL_ID: models.analysis,
-        // Index each dataset into the per-project catalog (search_datasets).
-        LANCEDB_FUNCTION_NAME: lancedbService.functionName,
       },
-    });
+    );
     // S3 (doc bucket) + DDB grants come from the allFunctions loop below.
     datasetProcess.addToRolePolicy(
       new iam.PolicyStatement({
-        actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+        actions: [
+          'bedrock:InvokeModel',
+          'bedrock:InvokeModelWithResponseStream',
+        ],
         resources: ['*'],
       }),
     );

--- a/packages/lambda/data-mcp/index.py
+++ b/packages/lambda/data-mcp/index.py
@@ -1,0 +1,396 @@
+"""Data MCP Lambda handler for AgentCore Gateway.
+
+Exposes three tools for querying structured datasets (Parquet) in a project:
+  - search_datasets(project_id, query): hybrid search the per-project catalog
+  - describe_dataset(project_id, dataset_uri): return the reference document (.txt)
+  - run_sql(project_id, dataset_uri(s), query): read-only DuckDB query over Parquet
+
+Parquet is read via pyarrow + s3fs and registered into DuckDB. All access is
+scoped to the given project_id; run_sql validates every dataset_uri against the
+project's DATASET# items before loading.
+"""
+
+import datetime
+import decimal
+import json
+import os
+import re
+from urllib.parse import urlparse
+
+import boto3
+import duckdb
+import pyarrow.parquet as pq
+import s3fs
+from boto3.dynamodb.conditions import Key
+
+TABLE_NAME = os.environ["BACKEND_TABLE_NAME"]
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+LANCEDB_FUNCTION_ARN = os.environ.get("LANCEDB_FUNCTION_ARN", "idp-v2-lance-service")
+
+# Number of datasets search_datasets returns to the LLM.
+SEARCH_DATASETS_LIMIT = int(os.environ.get("SEARCH_DATASETS_LIMIT", "10"))
+
+# Result guardrail: cap rows returned to the LLM regardless of dataset size.
+MAX_RESULT_ROWS = int(os.environ.get("MAX_RESULT_ROWS", "200"))
+
+# Memory guardrail: with method 2 (pyarrow reads the whole Parquet into memory),
+# reject queries whose combined row count would risk OOM. ~100k rows/dataset is
+# well within a 2 GB Lambda; this only blocks runaway multi-dataset loads.
+MAX_TOTAL_ROWS = int(os.environ.get("MAX_TOTAL_ROWS", "2000000"))
+
+
+def _to_jsonable(value):
+    """Convert DuckDB values to JSON-serializable primitives."""
+    if isinstance(value, (datetime.date, datetime.datetime, datetime.time)):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return float(value)
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+_ddb_table = boto3.resource("dynamodb", region_name=AWS_REGION).Table(TABLE_NAME)
+_s3 = boto3.client("s3", region_name=AWS_REGION)
+_lambda = boto3.client("lambda", region_name=AWS_REGION)
+
+# Reused across warm invocations. Parquet is read via pyarrow + s3fs and
+# registered into DuckDB, avoiding the httpfs extension (which fails to
+# download on Lambda's arm64 platform for the pinned DuckDB version).
+_con: duckdb.DuckDBPyConnection | None = None
+_fs: s3fs.S3FileSystem | None = None
+# Loaded Arrow tables kept alive so DuckDB's registration stays valid. Keyed by
+# dataset_uri; reused across invocations so warm calls skip the S3 read. The
+# cached S3 ETag is stored alongside so a re-converted/replaced Parquet (same
+# URI, new content) is detected and re-read instead of serving stale data.
+_tables: dict[str, object] = {}
+_etags: dict[str, str] = {}
+# Table names currently registered on the connection (so we can register several
+# datasets at once for JOINs, and clear stale ones between calls).
+_registered_names: set[str] = set()
+
+
+def _current_etag(dataset_uri: str) -> str | None:
+    """Return the S3 ETag for a dataset, or None if it can't be fetched."""
+    parsed = urlparse(dataset_uri)
+    try:
+        head = _s3.head_object(Bucket=parsed.netloc, Key=parsed.path.lstrip("/"))
+        return head.get("ETag")
+    except Exception:  # noqa: BLE001 - fall back to caching without invalidation
+        return None
+
+
+def _get_fs() -> s3fs.S3FileSystem:
+    global _fs
+    if _fs is None:
+        _fs = s3fs.S3FileSystem()
+    return _fs
+
+
+def _get_con() -> duckdb.DuckDBPyConnection:
+    global _con
+    if _con is None:
+        _con = duckdb.connect()
+    return _con
+
+
+def _dataset_id_from_uri(dataset_uri: str) -> str:
+    """Extract the dataset_id (the Parquet filename without extension) from a URI."""
+    return dataset_uri.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+
+
+def table_name_for(dataset_uri: str) -> str:
+    """Derive a safe SQL identifier from a dataset URI.
+
+    The dataset_id is document_id-based (e.g. 'e4c9-..-72bc' or '..__0'), which
+    is not a valid bare SQL identifier (hyphens, may start with a digit). Convert
+    it deterministically: 't_' + hex-only id, with '__N' sheet suffix kept as
+    '_sN'. Both this Lambda and the LLM use this same name, so they always agree.
+    Example: 'e4c95c84-f25f-...-72bc'      -> 't_e4c95c84f25f...72bc'
+             'e4c95c84-...__0'             -> 't_e4c95c84...' + '_s0'
+    """
+    dataset_id = _dataset_id_from_uri(dataset_uri)
+    sheet_suffix = ""
+    if "__" in dataset_id:
+        base, _, idx = dataset_id.rpartition("__")
+        if idx.isdigit():
+            dataset_id = base
+            sheet_suffix = f"_s{idx}"
+    sanitized = re.sub(r"[^0-9a-zA-Z]", "", dataset_id)
+    return f"t_{sanitized}{sheet_suffix}"
+
+
+def _register_datasets(dataset_uris: list[str]) -> dict[str, str]:
+    """Load each Parquet from S3 (cached) and register it under its derived name.
+
+    Registrations from a previous call are dropped first so table names never
+    leak across invocations. Returns a {dataset_uri: table_name} map. When a
+    single dataset is registered it is ALSO aliased as 'data' for backward
+    compatibility with existing prompts/reference docs that use `FROM data`.
+    """
+    global _registered_names
+    con = _get_con()
+
+    for name in _registered_names:
+        con.unregister(name)
+    _registered_names = set()
+
+    uri_to_name: dict[str, str] = {}
+    for dataset_uri in dataset_uris:
+        # Re-read when the Parquet is uncached or its S3 ETag changed (data was
+        # re-converted/replaced under the same URI).
+        etag = _current_etag(dataset_uri)
+        if dataset_uri not in _tables or (etag is not None and _etags.get(dataset_uri) != etag):
+            _tables[dataset_uri] = pq.read_table(dataset_uri, filesystem=_get_fs())
+            _etags[dataset_uri] = etag
+        name = table_name_for(dataset_uri)
+        con.register(name, _tables[dataset_uri])
+        _registered_names.add(name)
+        uri_to_name[dataset_uri] = name
+
+    if len(dataset_uris) == 1:
+        con.register("data", _tables[dataset_uris[0]])
+        _registered_names.add("data")
+
+    return uri_to_name
+
+
+def _query_datasets(project_id: str) -> list[dict]:
+    """Return all DATASET# items for a project."""
+    result = _ddb_table.query(
+        KeyConditionExpression=Key("PK").eq(f"PROJ#{project_id}")
+        & Key("SK").begins_with("DATASET#"),
+    )
+    return result.get("Items", [])
+
+
+def search_datasets(event: dict) -> dict:
+    """Find datasets relevant to a query via hybrid search over the per-project
+    catalog (LanceDB). Returns the top matches with their table_name for run_sql.
+
+    Replaces listing all datasets: with many datasets, returning the full list
+    wastes tokens and hurts selection. The catalog is populated by dataset-process
+    at conversion time.
+    """
+    project_id = event["project_id"]
+    query = event.get("query", "")
+
+    resp = _lambda.invoke(
+        FunctionName=LANCEDB_FUNCTION_ARN,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(
+            {
+                "action": "search_datasets",
+                "params": {
+                    "project_id": project_id,
+                    "query": query,
+                    "limit": SEARCH_DATASETS_LIMIT,
+                },
+            }
+        ),
+    )
+    payload = resp["Payload"].read().decode("utf-8")
+    if "FunctionError" in resp:
+        return {"error": f"Dataset search failed: {payload}"}
+
+    result = json.loads(payload)
+    datasets = []
+    for r in result.get("results", []):
+        dataset_uri = r.get("dataset_s3_uri")
+        datasets.append(
+            {
+                "dataset_uri": dataset_uri,
+                "table_name": table_name_for(dataset_uri) if dataset_uri else None,
+                "name": r.get("name"),
+                "description": r.get("description", ""),
+            }
+        )
+    return {"datasets": datasets}
+
+
+def describe_dataset(event: dict) -> dict:
+    project_id = event["project_id"]
+    dataset_uri = event["dataset_uri"]
+
+    # Find the dataset item to distinguish "unknown dataset" from "no reference doc".
+    data = None
+    for item in _query_datasets(project_id):
+        if item.get("data", {}).get("dataset_s3_uri") == dataset_uri:
+            data = item["data"]
+            break
+    if data is None:
+        return {
+            "error": (
+                f"Unknown dataset_uri for this project: {dataset_uri}. "
+                "Call search_datasets first."
+            )
+        }
+
+    # table_name is what the LLM must use in FROM. For a single-dataset query it
+    # can also use 'data'; for a JOIN across datasets it must use each table_name.
+    table_name = table_name_for(dataset_uri)
+
+    reference_uri = data.get("reference_s3_uri")
+    if reference_uri:
+        try:
+            parsed = urlparse(reference_uri)
+            obj = _s3.get_object(Bucket=parsed.netloc, Key=parsed.path.lstrip("/"))
+            reference = obj["Body"].read().decode("utf-8")
+            return {"table_name": table_name, "reference": reference}
+        except Exception:  # noqa: BLE001 - fall back to metadata below
+            pass
+
+    # No reference doc (generation failed/skipped): return a minimal description
+    # from the dataset metadata so Text2SQL can still work.
+    return {"table_name": table_name, "reference": _fallback_reference(data)}
+
+
+def _fallback_reference(data: dict) -> str:
+    name = data.get("name", "dataset")
+    columns = data.get("columns") or []
+    row_count = data.get("row_count")
+    lines = [
+        f"# Dataset: {name}",
+        "",
+        "Table name to use in SQL: `data`",
+    ]
+    if row_count is not None:
+        lines.append(f"Row count: {row_count}")
+    if columns:
+        lines.append("")
+        lines.append("## Columns")
+        for c in columns:
+            lines.append(f"- {c}")
+    lines.append("")
+    lines.append(
+        "Note: no detailed reference document is available for this dataset. "
+        "Use get column names above; quote names with spaces/special characters "
+        'in SQL (e.g. "Product hierarchy").'
+    )
+    return "\n".join(lines)
+
+
+def run_sql(event: dict) -> dict:
+    project_id = event["project_id"]
+    query = event["query"]
+
+    # Accept a single dataset_uri (backward compatible) or a list for JOINs.
+    dataset_uris = event.get("dataset_uris")
+    if not dataset_uris:
+        single = event.get("dataset_uri")
+        dataset_uris = [single] if single else []
+    if not dataset_uris:
+        return {"error": "Provide dataset_uri or dataset_uris (from search_datasets)."}
+    # De-duplicate while preserving order (same dataset referenced twice is fine).
+    seen: set[str] = set()
+    dataset_uris = [u for u in dataset_uris if not (u in seen or seen.add(u))]
+
+    # Every dataset must belong to the project. This is the isolation boundary:
+    # the LLM can only query datasets it discovered via list_datasets, never an
+    # arbitrary S3 path. Also gather row counts for the memory guard.
+    items = {
+        item["data"]["dataset_s3_uri"]: item["data"]
+        for item in _query_datasets(project_id)
+        if item.get("data", {}).get("dataset_s3_uri")
+    }
+    total_rows = 0
+    for uri in dataset_uris:
+        if uri not in items:
+            return {
+                "error": (
+                    f"Unknown dataset_uri for this project: {uri}. "
+                    "Call search_datasets first."
+                )
+            }
+        total_rows += items[uri].get("row_count") or 0
+
+    if total_rows > MAX_TOTAL_ROWS:
+        return {
+            "error": (
+                f"Datasets too large to load in memory ({total_rows} rows > "
+                f"{MAX_TOTAL_ROWS}). Query fewer/smaller datasets."
+            )
+        }
+
+    if not _is_read_only(query):
+        return {"error": "Only read-only SELECT/WITH queries are allowed."}
+
+    con = _get_con()
+
+    # Load each Parquet from S3 and expose it under its derived table name (and
+    # 'data' when there is exactly one dataset).
+    try:
+        _register_datasets(dataset_uris)
+    except Exception as e:  # noqa: BLE001 - surface any S3/Parquet read error
+        return {"error": f"Failed to load dataset: {e}"}
+
+    try:
+        cursor = con.execute(query)
+        columns = [d[0] for d in cursor.description]
+        # Fetch one extra row to detect truncation without a second query.
+        fetched = cursor.fetchmany(MAX_RESULT_ROWS + 1)
+    except duckdb.Error as e:
+        return {"error": f"Query failed: {e}"}
+
+    truncated = len(fetched) > MAX_RESULT_ROWS
+    rows = [
+        {col: _to_jsonable(val) for col, val in zip(columns, row)}
+        for row in fetched[:MAX_RESULT_ROWS]
+    ]
+
+    result: dict = {"rows": rows, "row_count": len(rows)}
+    if truncated:
+        result["truncated"] = True
+        result["note"] = (
+            f"Result truncated to {MAX_RESULT_ROWS} rows. "
+            "Add aggregation or a tighter WHERE/LIMIT for complete results."
+        )
+    return result
+
+
+_READ_ONLY_RE = re.compile(r"^\s*(select|with)\b", re.IGNORECASE)
+_FORBIDDEN_RE = re.compile(
+    r"\b(insert|update|delete|drop|create|alter|attach|copy|install|load|"
+    r"pragma|set|export|import|call)\b",
+    re.IGNORECASE,
+)
+# Match single- or double-quoted string literals so forbidden keywords inside
+# them (e.g. WHERE name = 'update me') are not treated as statements.
+_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
+
+
+def _is_read_only(query: str) -> bool:
+    """Allow only single SELECT/WITH statements; reject DDL/DML and multi-statements."""
+    stripped = query.strip().rstrip(";")
+    if not _READ_ONLY_RE.match(stripped):
+        return False
+    # Strip string literals before checking for statement separators and
+    # forbidden keywords, so quoted content cannot cause false negatives.
+    without_strings = _STRING_LITERAL_RE.sub("''", stripped)
+    if ";" in without_strings:
+        return False
+    if _FORBIDDEN_RE.search(without_strings):
+        return False
+    return True
+
+
+_TOOLS = {
+    "search_datasets": search_datasets,
+    "describe_dataset": describe_dataset,
+    "run_sql": run_sql,
+}
+
+
+def handler(event: dict, context) -> dict:
+    """AgentCore Gateway invokes with the tool name in clientContext.custom."""
+    tool_name = ""
+    client_context = getattr(context, "client_context", None)
+    if client_context is not None and getattr(client_context, "custom", None):
+        tool_name = client_context.custom.get("bedrockAgentCoreToolName", "")
+
+    action = tool_name.split("___")[-1] if "___" in tool_name else tool_name
+
+    fn = _TOOLS.get(action)
+    if fn is None:
+        return {"error": f"Unknown tool: {tool_name}"}
+    return fn(event)

--- a/packages/lambda/data-mcp/schema.json
+++ b/packages/lambda/data-mcp/schema.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "search_datasets",
+    "description": "Find structured datasets (Parquet tables) relevant to a natural-language query via hybrid search of the project's dataset catalog. Call this FIRST to discover which datasets can answer the question. Returns the top matches with dataset_uri, table_name, name, and description. Use the query to describe what data you need (e.g. 'menu plan materials', 'product prices').",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "The unique identifier of the project"
+        },
+        "query": {
+          "type": "string",
+          "description": "Natural-language description of the data you are looking for"
+        }
+      },
+      "required": ["project_id", "query"]
+    }
+  },
+  {
+    "name": "describe_dataset",
+    "description": "Return the reference document (schema, column dictionary, enum values, query patterns, caveats) for a dataset. Call this BEFORE writing SQL, using a dataset_uri from search_datasets. The returned document is the source of truth for column names and values - do NOT invent columns.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "The unique identifier of the project"
+        },
+        "dataset_uri": {
+          "type": "string",
+          "description": "S3 URI of the dataset Parquet file (from search_datasets)"
+        }
+      },
+      "required": ["project_id", "dataset_uri"]
+    }
+  },
+  {
+    "name": "run_sql",
+    "description": "Run a read-only DuckDB SQL query against one or more Parquet datasets. Single dataset: pass dataset_uri; it is exposed as table 'data' (FROM data). To JOIN across datasets (e.g. multiple sheets), pass dataset_uris (a list) and reference each by its table_name from search_datasets/describe_dataset. Columns are snake_case. Only SELECT/WITH allowed. Every dataset referenced in the SQL MUST be included in dataset_uri/dataset_uris. Example single: run_sql(project_id, dataset_uri, \"SELECT name FROM data ORDER BY attack DESC LIMIT 5\"). Example JOIN: run_sql(project_id, dataset_uris=[uriA, uriB], \"SELECT a.name, b.price FROM t_aaa a JOIN t_bbb b ON a.code = b.code\").",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "The unique identifier of the project"
+        },
+        "dataset_uri": {
+          "type": "string",
+          "description": "S3 URI of a single dataset Parquet file (from search_datasets). Use this for single-table queries; the table is named 'data'."
+        },
+        "dataset_uris": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of dataset S3 URIs to query together (from search_datasets). Use for JOINs; reference each by its table_name. Include every dataset your SQL uses."
+        },
+        "query": {
+          "type": "string",
+          "description": "Read-only SQL query. Use 'data' for a single dataset, or each dataset's table_name when joining."
+        }
+      },
+      "required": ["project_id", "query"]
+    }
+  }
+]

--- a/packages/lambda/lancedb-service/src/action/add_dataset.rs
+++ b/packages/lambda/lancedb-service/src/action/add_dataset.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use arrow_array::{FixedSizeListArray, Float32Array, Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field};
+use lancedb::Connection;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use crate::client;
+use crate::db;
+use crate::db::model::{dataset_catalog_schema, dataset_catalog_table};
+
+#[derive(Deserialize)]
+pub struct AddDatasetParams {
+    pub project_id: String,
+    pub dataset_id: String,
+    pub dataset_s3_uri: String,
+    pub name: String,
+    pub description: String,
+    pub columns: Option<Vec<String>>,
+    pub row_count: Option<i64>,
+    pub language: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct AddDatasetOutput {
+    pub success: bool,
+    pub dataset_id: String,
+}
+
+pub async fn execute(
+    conn: &Connection,
+    lambda_client: &aws_sdk_lambda::Client,
+    bedrock_client: &aws_sdk_bedrockruntime::Client,
+    params: AddDatasetParams,
+) -> Result<AddDatasetOutput, Box<dyn std::error::Error + Send + Sync>> {
+    let table_name = dataset_catalog_table(&params.project_id);
+    let lang = params.language.as_deref().unwrap_or("ko");
+
+    // Searchable text = name + description + column names. This is what a user's
+    // question is matched against to find the right dataset.
+    let columns = params.columns.unwrap_or_default();
+    let content = format!(
+        "{}\n{}\n{}",
+        params.name,
+        params.description,
+        columns.join(", ")
+    );
+
+    info!(
+        "[add_dataset] project_id: {}, dataset_id: {}, table: {table_name}",
+        params.project_id, params.dataset_id
+    );
+
+    let table =
+        db::table::get_or_create_table(conn, &table_name, dataset_catalog_schema()).await?;
+
+    // Keywords for FTS (hybrid search), same Toka path as documents.
+    let keywords = if content.is_empty() {
+        String::new()
+    } else {
+        client::toka::extract_keywords(lambda_client, &content, lang).await?
+    };
+
+    // Embedding for vector search.
+    let vector = client::bedrock::generate_embedding(bedrock_client, &content).await?;
+
+    let schema = dataset_catalog_schema();
+    let values = Arc::new(Float32Array::from(vector)) as arrow_array::ArrayRef;
+    let field = Arc::new(Field::new("item", DataType::Float32, true));
+    let vector_array = FixedSizeListArray::new(field, 1024, values, None);
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(vec![params.dataset_id.as_str()])),
+            Arc::new(StringArray::from(vec![params.dataset_s3_uri.as_str()])),
+            Arc::new(StringArray::from(vec![params.name.as_str()])),
+            Arc::new(StringArray::from(vec![params.description.as_str()])),
+            Arc::new(StringArray::from(vec![content.as_str()])),
+            Arc::new(vector_array),
+            Arc::new(StringArray::from(vec![keywords.as_str()])),
+            Arc::new(Int64Array::from(vec![params.row_count.unwrap_or(0)])),
+        ],
+    )?;
+
+    // A dataset is re-indexed on re-conversion; delete the old row first so the
+    // catalog never accumulates stale duplicates for the same dataset_id.
+    table
+        .delete(&format!("dataset_id = '{}'", params.dataset_id))
+        .await?;
+
+    info!("[add_dataset] Adding record to table...");
+    table.add(vec![batch]).execute().await?;
+
+    info!("[add_dataset] Record added successfully: {}", params.dataset_id);
+    Ok(AddDatasetOutput {
+        success: true,
+        dataset_id: params.dataset_id,
+    })
+}

--- a/packages/lambda/lancedb-service/src/action/mod.rs
+++ b/packages/lambda/lancedb-service/src/action/mod.rs
@@ -1,6 +1,8 @@
+pub mod add_dataset;
 pub mod add_graph_keywords;
 pub mod add_record;
 pub mod count;
+pub mod search_datasets;
 pub mod delete_by_workflow;
 pub mod delete_graph_keywords_by_project_id;
 pub mod delete_record;

--- a/packages/lambda/lancedb-service/src/action/search_datasets.rs
+++ b/packages/lambda/lancedb-service/src/action/search_datasets.rs
@@ -1,0 +1,98 @@
+use arrow_array::RecordBatch;
+use futures::TryStreamExt;
+use lance_index::scalar::FullTextSearchQuery;
+use lancedb::Connection;
+use lancedb::index::Index;
+use lancedb::query::{ExecutableQuery, QueryBase, Select};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use crate::client;
+use crate::db;
+use crate::db::model::{dataset_catalog_table, ScoredDataset};
+
+#[derive(Deserialize)]
+pub struct SearchDatasetsParams {
+    pub project_id: String,
+    pub query: String,
+    pub limit: Option<u32>,
+    pub language: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct SearchDatasetsOutput {
+    pub success: bool,
+    pub results: Vec<ScoredDataset>,
+}
+
+pub async fn execute(
+    conn: &Connection,
+    lambda_client: &aws_sdk_lambda::Client,
+    bedrock_client: &aws_sdk_bedrockruntime::Client,
+    params: SearchDatasetsParams,
+) -> lancedb::error::Result<SearchDatasetsOutput> {
+    let table_name = dataset_catalog_table(&params.project_id);
+
+    // No catalog yet for this project -> no datasets.
+    let table_names = db::table::list_tables(conn).await?;
+    if !table_names.contains(&table_name) {
+        return Ok(SearchDatasetsOutput {
+            success: true,
+            results: vec![],
+        });
+    }
+
+    let table = conn.open_table(&table_name).execute().await?;
+
+    info!("[search_datasets] Creating FTS index on keywords...");
+    table
+        .create_index(&["keywords"], Index::FTS(Default::default()))
+        .replace(true)
+        .execute()
+        .await?;
+
+    let lang = params.language.as_deref().unwrap_or("ko");
+    let keywords = client::toka::extract_keywords(lambda_client, &params.query, lang)
+        .await
+        .map_err(|e| lancedb::error::Error::Runtime {
+            message: format!("toka error: {e}"),
+        })?;
+
+    let embedding = client::bedrock::generate_embedding(bedrock_client, &params.query)
+        .await
+        .map_err(|e| lancedb::error::Error::Runtime {
+            message: format!("bedrock error: {e}"),
+        })?;
+
+    let limit = params.limit.unwrap_or(10) as usize;
+    let fts_query = FullTextSearchQuery::new(keywords);
+
+    info!("[search_datasets] Executing hybrid search, limit: {limit}");
+    let batches: Vec<RecordBatch> = table
+        .query()
+        .full_text_search(fts_query)
+        .select(Select::columns(&[
+            "dataset_id",
+            "dataset_s3_uri",
+            "name",
+            "description",
+            "row_count",
+        ]))
+        .limit(limit)
+        .nearest_to(embedding.as_slice())
+        .map_err(|e| lancedb::error::Error::Runtime {
+            message: format!("nearest_to error: {e}"),
+        })?
+        .execute()
+        .await?
+        .try_collect()
+        .await?;
+
+    let results: Vec<ScoredDataset> = batches.iter().flat_map(ScoredDataset::from_batch).collect();
+    info!("[search_datasets] Found {} results", results.len());
+
+    Ok(SearchDatasetsOutput {
+        success: true,
+        results,
+    })
+}

--- a/packages/lambda/lancedb-service/src/db/model.rs
+++ b/packages/lambda/lancedb-service/src/db/model.rs
@@ -123,6 +123,89 @@ impl ScoredKeyword {
     }
 }
 
+/// A structured-dataset catalog entry: one row per dataset (Excel sheet / CSV),
+/// used to search for relevant datasets by name/description rather than listing
+/// them all. Stored in a per-project table named "{project_id}_datasets".
+#[derive(Serialize)]
+pub struct Dataset {
+    pub dataset_id: String,
+    pub dataset_s3_uri: String,
+    pub name: String,
+    pub description: String,
+    pub row_count: i64,
+}
+
+impl Dataset {
+    pub fn from_batch(batch: &RecordBatch) -> Vec<Self> {
+        let dataset_ids = batch.column_by_name("dataset_id").unwrap().as_string::<i32>();
+        let uris = batch.column_by_name("dataset_s3_uri").unwrap().as_string::<i32>();
+        let names = batch.column_by_name("name").unwrap().as_string::<i32>();
+        let descriptions = batch.column_by_name("description").unwrap().as_string::<i32>();
+        let row_counts = batch.column_by_name("row_count").unwrap().as_primitive::<arrow_array::types::Int64Type>();
+
+        (0..batch.num_rows())
+            .map(|i| Dataset {
+                dataset_id: dataset_ids.value(i).to_string(),
+                dataset_s3_uri: uris.value(i).to_string(),
+                name: names.value(i).to_string(),
+                description: descriptions.value(i).to_string(),
+                row_count: row_counts.value(i),
+            })
+            .collect()
+    }
+}
+
+#[derive(Serialize)]
+pub struct ScoredDataset {
+    #[serde(flatten)]
+    pub dataset: Dataset,
+    pub score: f32,
+}
+
+impl ScoredDataset {
+    pub fn from_batch(batch: &RecordBatch) -> Vec<Self> {
+        let datasets = Dataset::from_batch(batch);
+        let scores = batch.column_by_name("_relevance_score").unwrap().as_primitive::<arrow_array::types::Float32Type>();
+
+        datasets
+            .into_iter()
+            .enumerate()
+            .map(|(i, dataset)| ScoredDataset {
+                dataset,
+                score: scores.value(i),
+            })
+            .collect()
+    }
+}
+
+/// Per-project dataset-catalog table name: "{project_id}_datasets".
+pub fn dataset_catalog_table(project_id: &str) -> String {
+    format!("{project_id}_datasets")
+}
+
+/// Arrow schema for the dataset catalog. One row per dataset (Excel sheet / CSV).
+/// `content` (name + description + column names) is embedded into `vector`, and
+/// `keywords` backs the FTS index for hybrid search.
+pub fn dataset_catalog_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("dataset_id", DataType::Utf8, false),
+        Field::new("dataset_s3_uri", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+        Field::new("content", DataType::Utf8, false),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                VECTOR_DIMENSION,
+            ),
+            false,
+        ),
+        Field::new("keywords", DataType::Utf8, false),
+        Field::new("row_count", DataType::Int64, false),
+    ]))
+}
+
 pub const GRAPH_KEYWORDS_TABLE: &str = "graph_keywords";
 
 /// Arrow schema for the keywords table in LanceDB.

--- a/packages/lambda/lancedb-service/src/lib.rs
+++ b/packages/lambda/lancedb-service/src/lib.rs
@@ -11,6 +11,12 @@ pub enum LanceDbAction {
     #[serde(rename = "add_graph_keywords")]
     AddGraphKeywords(add_graph_keywords::AddGraphKeywordsParams),
 
+    #[serde(rename = "add_dataset")]
+    AddDataset(add_dataset::AddDatasetParams),
+
+    #[serde(rename = "search_datasets")]
+    SearchDatasets(search_datasets::SearchDatasetsParams),
+
     #[serde(rename = "add_record")]
     AddRecord(add_record::AddRecordParams),
 

--- a/packages/lambda/lancedb-service/src/main.rs
+++ b/packages/lambda/lancedb-service/src/main.rs
@@ -1,6 +1,6 @@
 use lambda_runtime::{Error, LambdaEvent, service_fn};
 use lancedb_service::LanceDbAction;
-use lancedb_service::action::{add_graph_keywords, add_record, count, delete_by_workflow, delete_graph_keywords_by_project_id, delete_record, drop_table, get_by_qa_ids, get_by_segment_ids, get_graph_keywords, get_segments_by_document_id, hybrid_search, list_tables, search_graph_keywords};
+use lancedb_service::action::{add_dataset, add_graph_keywords, add_record, count, delete_by_workflow, delete_graph_keywords_by_project_id, delete_record, drop_table, get_by_qa_ids, get_by_segment_ids, get_graph_keywords, get_segments_by_document_id, hybrid_search, list_tables, search_datasets, search_graph_keywords};
 use lancedb_service::db;
 use serde::Serialize;
 use tracing::info;
@@ -49,6 +49,12 @@ async fn handler(
 
     let result: Result<serde_json::Value, (u16, String)> = match action {
         LanceDbAction::AddGraphKeywords(params) => add_graph_keywords::execute(&conn, bedrock_client, params).await
+            .map_err(|e| (500, e.to_string()))
+            .and_then(|v| serde_json::to_value(v).map_err(|e| (500, e.to_string()))),
+        LanceDbAction::AddDataset(params) => add_dataset::execute(&conn, lambda_client, bedrock_client, params).await
+            .map_err(|e| (500, e.to_string()))
+            .and_then(|v| serde_json::to_value(v).map_err(|e| (500, e.to_string()))),
+        LanceDbAction::SearchDatasets(params) => search_datasets::execute(&conn, lambda_client, bedrock_client, params).await
             .map_err(|e| (500, e.to_string()))
             .and_then(|v| serde_json::to_value(v).map_err(|e| (500, e.to_string()))),
         LanceDbAction::ListTables => list_tables::execute(&conn).await

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,9 +394,15 @@ importers:
 
   packages/frontend:
     dependencies:
+      '@codemirror/lang-sql':
+        specifier: ^6.10.0
+        version: 6.10.0
       '@types/d3-cloud':
         specifier: ^1.2.9
         version: 1.2.9
+      '@uiw/react-codemirror':
+        specifier: ^4.25.10
+        version: 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       d3-cloud:
         specifier: ^1.2.9
         version: 1.2.9
@@ -1677,6 +1683,33 @@ packages:
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.10.4':
+    resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/search@6.7.1':
+    resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
+
+  '@codemirror/state@6.7.1':
+    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.43.6':
+    resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==}
+
   '@csstools/color-helpers@6.1.0':
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
     engines: {node: '>=20.19.0'}
@@ -2847,6 +2880,15 @@ packages:
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
   '@ltd/j-toml@1.38.0':
     resolution: {integrity: sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==}
 
@@ -2854,6 +2896,9 @@ packages:
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@marijn/find-cluster-break@1.0.3':
+    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -4716,6 +4761,28 @@ packages:
     resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.10':
+    resolution: {integrity: sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ==}
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.10':
+    resolution: {integrity: sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
@@ -5847,6 +5914,9 @@ packages:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -6032,6 +6102,9 @@ packages:
   crc32-stream@6.0.0:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -9852,6 +9925,9 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -10659,6 +10735,9 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -13032,6 +13111,68 @@ snapshots:
 
   '@chevrotain/utils@11.1.2': {}
 
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.4':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      crelt: 1.0.7
+
+  '@codemirror/search@6.7.1':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      crelt: 1.0.7
+
+  '@codemirror/state@6.7.1':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.3
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.43.6':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -13823,6 +13964,16 @@ snapshots:
       '@lancedb/lancedb-win32-arm64-msvc': 0.23.0
       '@lancedb/lancedb-win32-x64-msvc': 0.23.0
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
   '@ltd/j-toml@1.38.0': {}
 
   '@mapbox/node-pre-gyp@2.0.3(encoding@0.1.13)':
@@ -13837,6 +13988,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@marijn/find-cluster-break@1.0.3': {}
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -16406,6 +16559,33 @@ snapshots:
       '@typescript-eslint/types': 8.62.0
       eslint-visitor-keys: 5.0.1
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.10(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.4
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+
+  '@uiw/react-codemirror@4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@codemirror/commands': 6.10.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.43.6
+      '@uiw/codemirror-extensions-basic-setup': 4.25.10(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
+      codemirror: 6.0.2
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@ungap/structured-clone@1.3.2': {}
@@ -18172,6 +18352,16 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.4
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -18338,6 +18528,8 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
+
+  crelt@1.0.7: {}
 
   cron-parser@4.9.0:
     dependencies:
@@ -23241,6 +23433,8 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -23956,6 +24150,8 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
  - 정형 데이터(xlsx/csv/tsv) 파이프라인 추가: type-detection 분기 → DatasetProcess Lambda(validate→parquet→레퍼런스 문서→DATASET#)
  - data-mcp Lambda 추가(DuckDB): describe_dataset/run_sql, 여러 parquet 멀티뷰 register로 시트 간 JOIN 지원
  - parquet 변환 시 컬럼명 snake_case 정규화(중복 컬럼 자동 유니크화), 멀티시트는 시트별 개별 dataset
  - dataset 카탈로그 hybrid 검색: lancedb-service에 add_dataset/search_datasets 추가(프로젝트별 테이블), list_datasets를 search_datasets로 대체
  - run_sql 가드레일: read-only 강제, 결과 행수/메모리 상한, project 격리, S3 ETag 캐시 무효화
  - backend: dataset 조회 API(schema/rows/query), 프로젝트 삭제 시 카탈로그 테이블 drop
  - 프론트: Data 업로드 탭, 문서 상세 SQL 워크벤치(CodeMirror)+시트 콤보+description, 파일 크기 KB 표시, 탭별 확장자 필터
  - idp-agent 프롬프트·검색 스킬에 정형/비정형 분기 및 JOIN 워크플로우 반영