### PR TITLE
Upgrade models to Sonnet 5 and Opus 4.8

### DIFF
--- a/packages/agents/idp-agent/config.py
+++ b/packages/agents/idp-agent/config.py
@@ -13,7 +13,7 @@ class Config(BaseSettings):
     agentcore_runtime_id: str = ""
     backend_table_name: str = ""
     websocket_message_queue_url: str = ""
-    bedrock_model_id: str = "global.anthropic.claude-opus-4-6-v1"
+    bedrock_model_id: str = "global.anthropic.claude-opus-4-8"
     code_interpreter_identifier: str = ""
 
     @property

--- a/packages/agents/research-agent/agents/constants.py
+++ b/packages/agents/research-agent/agents/constants.py
@@ -1,9 +1,9 @@
-SONNET_4_6 = "global.anthropic.claude-sonnet-4-6"
+SONNET_5 = "global.anthropic.claude-sonnet-5"
 HAIKU_4_5 = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
-OPUS_4_6 = "global.anthropic.claude-opus-4-6-v1"
+OPUS_4_8 = "global.anthropic.claude-opus-4-8"
 
-SUPERVISOR_MODEL_ID = SONNET_4_6
-REPORT_MODEL_ID = SONNET_4_6
+SUPERVISOR_MODEL_ID = SONNET_5
+REPORT_MODEL_ID = SONNET_5
 RESEARCH_MODEL_ID = HAIKU_4_5
-PLAN_MODEL_ID = OPUS_4_6
-WRITE_MODEL_ID = OPUS_4_6
+PLAN_MODEL_ID = OPUS_4_8
+WRITE_MODEL_ID = OPUS_4_8

--- a/packages/agents/webcrawler-agent/config.py
+++ b/packages/agents/webcrawler-agent/config.py
@@ -14,7 +14,7 @@ class Config(BaseSettings):
     backend_table_name: str = os.environ.get("BACKEND_TABLE_NAME", "")
     agent_storage_bucket_name: str = os.environ.get("AGENT_STORAGE_BUCKET_NAME", "")
     bedrock_model_id: str = os.environ.get(
-        "BEDROCK_MODEL_ID", "global.anthropic.claude-sonnet-4-6"
+        "BEDROCK_MODEL_ID", "global.anthropic.claude-sonnet-5"
     )
 
 

--- a/packages/infra/src/functions/step-functions/graph-builder/test_normalizer.py
+++ b/packages/infra/src/functions/step-functions/graph-builder/test_normalizer.py
@@ -2,7 +2,7 @@
 
 Usage:
     python -m pytest test_normalizer.py -v
-    ENTITY_NORMALIZATION_MODEL_ID=global.anthropic.claude-sonnet-4-6 python -m pytest test_normalizer.py -v -s
+    ENTITY_NORMALIZATION_MODEL_ID=global.anthropic.claude-sonnet-5 python -m pytest test_normalizer.py -v -s
 """
 import json
 import sys

--- a/packages/infra/src/models.json
+++ b/packages/infra/src/models.json
@@ -1,12 +1,12 @@
 {
-  "analysis": "global.anthropic.claude-sonnet-4-6",
-  "docSummarizer": "global.anthropic.claude-sonnet-4-6",
+  "analysis": "global.anthropic.claude-sonnet-5",
+  "docSummarizer": "global.anthropic.claude-sonnet-5",
   "summarizer": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
   "describer": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
   "extractor": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-  "entityNormalizer": "global.anthropic.claude-sonnet-4-6",
+  "entityNormalizer": "global.anthropic.claude-sonnet-5",
   "embedding": "amazon.nova-2-multimodal-embeddings-v1:0",
   "videoAnalysis": "us.twelvelabs.pegasus-1-2-v1:0",
   "scriptExtractor": "global.amazon.nova-2-lite-v1:0",
-  "webcrawler": "global.anthropic.claude-sonnet-4-6"
+  "webcrawler": "global.anthropic.claude-sonnet-5"
 }

--- a/packages/infra/src/stacks/agent-stack.ts
+++ b/packages/infra/src/stacks/agent-stack.ts
@@ -207,7 +207,7 @@ export class AgentStack extends Stack {
       sessionStorageBucket,
       backendTable,
       gateway,
-      bedrockModelId: 'global.anthropic.claude-sonnet-4-6',
+      bedrockModelId: 'global.anthropic.claude-sonnet-5',
       agentStorageBucket,
       websocketMessageQueue,
       codeInterpreterIdentifier: idpCodeInterpreter.codeInterpreterId,


### PR DESCRIPTION
  - models.json 분석/요약/엔티티정규화/웹크롤러 모델을 Sonnet 4.6 → 5.0으로 업그레이드
  - idp-agent, research-agent(plan/write) 모델을 Opus 4.6 → 4.8로 업그레이드
  - research-agent(supervisor/report), webcrawler-agent 모델을 Sonnet 5.0으로 업그레이드
  - agent-stack 런타임 bedrockModelId를 Sonnet 5.0으로 변경
  - research-agent constants 변수명을 SONNET_5 / OPUS_4_8로 정리