### PR TITLE
Add chat cancellation and harden UI resource cleanup

### DIFF
--- a/packages/agents/idp-agent/main.py
+++ b/packages/agents/idp-agent/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import sys
 
@@ -107,9 +108,21 @@ async def invoke(request: dict):
     ) as agent:
         content = [block.to_strands() for block in req.prompt]
         stream = agent.stream_async(content)
-        async for event in stream:
-            for filtered in filter_stream_event(event):
-                yield filtered
+        try:
+            async for event in stream:
+                for filtered in filter_stream_event(event):
+                    yield filtered
+        except (GeneratorExit, asyncio.CancelledError):
+            # The client disconnected (user pressed Stop) — AgentCore tears down
+            # this generator. Cancel the running agent so it stops gracefully at
+            # the next checkpoint (model streaming / before tool execution).
+            # Strands then emits cancel tool_results, keeping the session
+            # consistent so the next turn resumes cleanly.
+            agent.cancel()
+            raise
+        finally:
+            # Ensure the underlying stream is closed even on cancellation.
+            await stream.aclose()
 
 
 if __name__ == "__main__":

--- a/packages/agents/idp-agent/prompts.py
+++ b/packages/agents/idp-agent/prompts.py
@@ -74,10 +74,15 @@ You can query two kinds of data. Choose based on the question:
 
 ### Using structured data tools (Text2SQL)
 1. Call `search_datasets` with a description of the data you need to find relevant datasets (projects may have many).
-2. Call `describe_dataset` to learn its columns, types, and enum values BEFORE writing SQL.
-   The reference document is the source of truth — do NOT invent column names or values.
-3. Call `run_sql` with a read-only DuckDB query. The dataset is exposed as the table `data`
-   (always query `FROM data`). Only SELECT/WITH is allowed.
+2. Call `describe_dataset` for each dataset you plan to query, to learn its columns, types,
+   enum values, AND its `table_name` BEFORE writing SQL. The reference document is the source
+   of truth — do NOT invent column names or values. Columns are snake_case.
+3. Call `run_sql` with a read-only DuckDB query (SELECT/WITH only):
+   - Single dataset: pass `dataset_uri`; the table is named `data` (query `FROM data`).
+   - Multiple datasets / multi-sheet JOIN: pass `dataset_uris` (a list of the dataset URIs
+     your query touches) and reference each by its `table_name` from `describe_dataset`
+     (e.g. `FROM t_aaa a JOIN t_bbb b ON a.material = b.material`). Include EVERY dataset the
+     SQL uses in `dataset_uris`.
 4. Base the answer only on query results; show the SQL you used in a code block.
 
 ### Cross questions (span both)

--- a/packages/frontend/src/components/ChatPanel/ChatInputBox.tsx
+++ b/packages/frontend/src/components/ChatPanel/ChatInputBox.tsx
@@ -9,6 +9,7 @@ import {
   Settings2,
   Sparkles,
   Mic,
+  Square,
 } from 'lucide-react';
 import { formatFileSize, getFileTypeInfo } from './utils';
 import { useRuntimeConfig } from '../../hooks/useRuntimeConfig';
@@ -46,6 +47,7 @@ interface ChatInputBoxProps {
   selectedAgent: Agent | null;
   onInputChange: (value: string) => void;
   onSendMessage: (files: AttachedFile[], message?: string) => void;
+  onStop?: () => void;
   onAgentSelect?: (agentName: string | null) => void;
   onAgentClick: () => void;
   voiceChat: InputBoxVoiceChat;
@@ -67,6 +69,7 @@ export default function ChatInputBox({
   selectedAgent,
   onInputChange,
   onSendMessage,
+  onStop,
   onAgentSelect,
   onAgentClick,
   voiceChat,
@@ -700,42 +703,60 @@ export default function ChatInputBox({
                 </>
               )}
             </div>
-            <button
-              onClick={handleSend}
-              disabled={!hasContent || sending}
-              type="button"
-              className={`inline-flex items-center justify-center h-8 w-8 rounded-xl transition-all active:scale-95 ${
-                hasContent && !sending
-                  ? voiceChat.mode
-                    ? 'bg-purple-500 hover:bg-purple-600 text-white shadow-md'
-                    : 'bg-blue-500 hover:bg-blue-600 text-white shadow-md'
-                  : 'bg-slate-200 dark:bg-white/15 text-slate-400 cursor-not-allowed'
-              }`}
-            >
-              {sending ? (
-                <svg
-                  className="w-4 h-4 animate-spin"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                  />
-                </svg>
-              ) : (
-                <ArrowUp className="w-4 h-4" />
-              )}
-            </button>
+            {sending && onStop ? (
+              // While a response streams, the send button becomes a Stop button
+              // that cancels the in-progress generation.
+              <button
+                onClick={onStop}
+                type="button"
+                title={t('chat.stop', 'Stop')}
+                aria-label={t('chat.stop', 'Stop')}
+                className="inline-flex items-center justify-center h-8 w-8 rounded-xl transition-all active:scale-95 text-white shadow-md bg-slate-700 hover:bg-slate-800 dark:bg-slate-600 dark:hover:bg-slate-500"
+              >
+                <Square
+                  className="w-3.5 h-3.5"
+                  fill="currentColor"
+                  strokeWidth={0}
+                />
+              </button>
+            ) : (
+              <button
+                onClick={handleSend}
+                disabled={!hasContent || sending}
+                type="button"
+                className={`inline-flex items-center justify-center h-8 w-8 rounded-xl transition-all active:scale-95 ${
+                  hasContent && !sending
+                    ? voiceChat.mode
+                      ? 'bg-purple-500 hover:bg-purple-600 text-white shadow-md'
+                      : 'bg-blue-500 hover:bg-blue-600 text-white shadow-md'
+                    : 'bg-slate-200 dark:bg-white/15 text-slate-400 cursor-not-allowed'
+                }`}
+              >
+                {sending ? (
+                  <svg
+                    className="w-4 h-4 animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                    />
+                  </svg>
+                ) : (
+                  <ArrowUp className="w-4 h-4" />
+                )}
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/packages/frontend/src/components/ChatPanel/index.tsx
+++ b/packages/frontend/src/components/ChatPanel/index.tsx
@@ -42,6 +42,7 @@ export default function ChatPanel({
   documents = [],
   onInputChange,
   onSendMessage,
+  onStop,
   onAgentSelect,
   onAgentClick,
   onNewChat,
@@ -336,6 +337,7 @@ export default function ChatPanel({
       selectedAgent={selectedAgent}
       onInputChange={onInputChange}
       onSendMessage={onSendMessage}
+      onStop={onStop}
       onAgentSelect={onAgentSelect}
       onAgentClick={onAgentClick}
       voiceChat={{

--- a/packages/frontend/src/components/ChatPanel/types.ts
+++ b/packages/frontend/src/components/ChatPanel/types.ts
@@ -79,6 +79,7 @@ export interface ChatPanelProps {
   documents?: Document[];
   onInputChange: (value: string) => void;
   onSendMessage: (files: AttachedFile[], message?: string) => void;
+  onStop?: () => void;
   onAgentSelect?: (agentName: string | null) => void;
   onAgentClick: () => void;
   onNewChat: () => void;

--- a/packages/frontend/src/components/DatasetView.tsx
+++ b/packages/frontend/src/components/DatasetView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2, ChevronLeft, ChevronRight, Play } from 'lucide-react';
 import CodeMirror from '@uiw/react-codemirror';
@@ -62,11 +62,27 @@ export default function DatasetView({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Monotonic request id: only the newest run may update state. Guards against
+  // out-of-order responses (fast sheet/page/query switches) overwriting the
+  // latest result, and against setState after unmount.
+  const requestSeqRef = useRef(0);
+  useEffect(() => {
+    return () => {
+      // Bump on unmount so any in-flight response is discarded.
+      requestSeqRef.current += 1;
+    };
+  }, []);
+
+  // Stable extensions array so CodeMirror doesn't reconfigure every render.
+  const sqlExtensions = useMemo(() => [sql()], []);
+
   const selected = datasets.find((d) => d.dataset_id === selectedId) ?? null;
 
   // Run a query (a specific page of it) against the selected dataset.
   const runPage = useCallback(
     (datasetId: string, query: string, pageOffset: number) => {
+      const seq = ++requestSeqRef.current;
+      const isStale = () => seq !== requestSeqRef.current;
       setLoading(true);
       setError(null);
       fetchApiRef
@@ -83,11 +99,13 @@ export default function DatasetView({
           },
         )
         .then((res) => {
+          if (isStale()) return;
           setResult(res);
           setOffset(pageOffset);
           setRanQuery(query);
         })
         .catch((e: unknown) => {
+          if (isStale()) return;
           setResult(null);
           setError(
             e instanceof Error
@@ -95,7 +113,10 @@ export default function DatasetView({
               : t('dataset.queryFailed', 'Query failed'),
           );
         })
-        .finally(() => setLoading(false));
+        .finally(() => {
+          if (isStale()) return;
+          setLoading(false);
+        });
     },
     [projectId, t],
   );
@@ -172,7 +193,7 @@ export default function DatasetView({
             value={queryText}
             height="200px"
             theme={isDark ? 'dark' : 'light'}
-            extensions={[sql()]}
+            extensions={sqlExtensions}
             onChange={setQueryText}
             onKeyDown={(e) => {
               if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {

--- a/packages/frontend/src/components/GraphView/ForceGraphView3D.tsx
+++ b/packages/frontend/src/components/GraphView/ForceGraphView3D.tsx
@@ -114,10 +114,12 @@ function getOrCreateLabelTexture(
 
 function createSpriteLabel(text: string, color: string): THREE.Sprite {
   const { texture, scaleX, scaleY } = getOrCreateLabelTexture(text, color);
-  const spriteMaterial = new THREE.SpriteMaterial({
-    map: texture,
-    depthWrite: false,
-  });
+  const spriteMaterial = markPerNode(
+    new THREE.SpriteMaterial({
+      map: texture,
+      depthWrite: false,
+    }),
+  );
   const sprite = new THREE.Sprite(spriteMaterial);
   sprite.scale.set(scaleX, scaleY, 1);
   return sprite;
@@ -137,6 +139,49 @@ function getOrCreatePageTexture(
     pageTextureCache.set(key, texture);
   }
   return texture;
+}
+
+// Mark a material as per-node (created fresh for one node, not from a shared
+// cache) so cleanup can dispose only these and leave shared cached materials
+// intact. Its `.map` (if any) is always a shared cached texture — never dispose.
+function markPerNode<T extends THREE.Material>(mat: T): T {
+  mat.userData.perNode = true;
+  return mat;
+}
+
+// Dispose ONLY per-node materials on a group's objects (never `.map`/geometry,
+// which are shared). Used both when refreshing the node cache and on unmount.
+function disposePerNodeMaterials(group: THREE.Object3D): void {
+  group.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) && !(child instanceof THREE.Sprite)) {
+      return;
+    }
+    const mat = child.material as
+      | THREE.Material
+      | THREE.Material[]
+      | null
+      | undefined;
+    if (!mat) return;
+    if (Array.isArray(mat)) {
+      mat.forEach((m) => m.userData.perNode && m.dispose());
+    } else if (mat.userData.perNode) {
+      mat.dispose();
+    }
+  });
+}
+
+// Dispose every shared module-level GPU cache (textures, materials, geometry).
+// Called once on unmount; the geometry cache is recreated for a fresh remount.
+function disposeSharedCaches(): void {
+  for (const t of labelTextureCache.values()) t.dispose();
+  labelTextureCache.clear();
+  labelScaleCache.clear();
+  for (const t of pageTextureCache.values()) t.dispose();
+  pageTextureCache.clear();
+  for (const m of materialCache.values()) m.dispose();
+  materialCache.clear();
+  Object.values(geometryCache).forEach((g) => g.dispose());
+  geometryCache = createGeometryCache();
 }
 
 const materialCache = new Map<string, THREE.MeshLambertMaterial>();
@@ -305,57 +350,30 @@ export default function ForceGraphView({
 
   // Cleanup Three.js renderer and cached objects on unmount
   useEffect(() => {
-    const fg = fgRef.current;
-    const cache = nodeObjectCache.current;
     return () => {
+      // Read refs inside cleanup, not at mount: fgRef.current is null at mount
+      // (ForceGraph3D fills it after first render), and nodeObjectCache.current
+      // is swapped for a fresh Map on each graph change — capturing either above
+      // would skip disposal / free a stale cache. Reading the latest here is
+      // intended, so the exhaustive-deps ref warning is suppressed.
+      const cache = nodeObjectCache.current;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const fg = fgRef.current;
+      // Each shared texture/material/geometry is disposed exactly once, by
+      // disposeSharedCaches() below. The scene and node-cache passes here only
+      // detach objects (scene.clear) and free PER-NODE materials — they must not
+      // touch shared resources (geometry, `.map`, cached materials), or those
+      // would be double-disposed.
       if (fg) {
         const renderer = fg.renderer?.();
-        if (renderer) {
-          renderer.dispose();
-        }
-        const scene = fg.scene?.();
-        if (scene) {
-          scene.traverse((obj) => {
-            if (obj instanceof THREE.Mesh) {
-              obj.geometry?.dispose();
-              if (Array.isArray(obj.material)) {
-                obj.material.forEach((m) => m.dispose());
-              } else if (obj.material) {
-                obj.material.dispose();
-              }
-            } else if (obj instanceof THREE.Sprite) {
-              obj.material?.map?.dispose();
-              obj.material?.dispose();
-            }
-          });
-          scene.clear();
-        }
+        renderer?.dispose();
+        fg.scene?.()?.clear();
       }
-      // Dispose cached node objects
       for (const group of cache.values()) {
-        group.traverse((child) => {
-          if (child instanceof THREE.Mesh) {
-            child.geometry?.dispose();
-            if (child.material instanceof THREE.Material) {
-              child.material.dispose();
-            }
-          } else if (child instanceof THREE.Sprite) {
-            child.material?.map?.dispose();
-            child.material?.dispose();
-          }
-        });
+        disposePerNodeMaterials(group);
       }
       cache.clear();
-      // Dispose module-level caches
-      for (const t of labelTextureCache.values()) t.dispose();
-      labelTextureCache.clear();
-      labelScaleCache.clear();
-      for (const t of pageTextureCache.values()) t.dispose();
-      pageTextureCache.clear();
-      for (const m of materialCache.values()) m.dispose();
-      materialCache.clear();
-      Object.values(geometryCache).forEach((g) => g.dispose());
-      geometryCache = createGeometryCache();
+      disposeSharedCaches();
     };
   }, []);
 
@@ -589,6 +607,19 @@ export default function ForceGraphView({
     incoming,
   ]);
 
+  // Bump a version whenever graphData changes and fold it into the node cache
+  // key. Computed during render (not in an effect), so a rebuilt graph yields
+  // fresh keys BEFORE force-graph calls nodeThreeObject — a node that kept its
+  // id but changed color/type/radius/label can never reuse a stale cached object
+  // for a frame. Deferred disposal of the old objects still happens in the
+  // cache-refresh effect below.
+  const graphVersionRef = useRef(0);
+  const graphVersion = useMemo(() => {
+    graphVersionRef.current += 1;
+    return graphVersionRef.current;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graphData]);
+
   // Zoom to fit after data changes
   useEffect(() => {
     const fg = fgRef.current;
@@ -599,6 +630,12 @@ export default function ForceGraphView({
         : graphData.nodes.length > 100
           ? 1500
           : 500;
+    // Track the nested timer + RAF so unmount / graph change cancels the whole
+    // chain. `cancelled` also stops the orbit animation loop.
+    let cancelled = false;
+    let orbitTimer: ReturnType<typeof setTimeout> | null = null;
+    let rafId = 0;
+
     const timer = setTimeout(() => {
       const nodeCount = graphData.nodes.length;
       let padding = 0;
@@ -609,7 +646,7 @@ export default function ForceGraphView({
       fg.zoomToFit(400, padding);
 
       // Cinematic orbit after zoom settles
-      const orbitTimer = setTimeout(() => {
+      orbitTimer = setTimeout(() => {
         const cam = fg.camera?.();
         if (!cam) return;
         const dist = cam.position.length() || 300;
@@ -619,6 +656,7 @@ export default function ForceGraphView({
         const totalAngle = Math.PI * 0.6;
         const t0 = performance.now();
         const animate = () => {
+          if (cancelled) return;
           const elapsed = performance.now() - t0;
           const progress = Math.min(elapsed / duration, 1);
           const ease = 1 - Math.pow(1 - progress, 3);
@@ -631,14 +669,18 @@ export default function ForceGraphView({
             },
             { x: 0, y: 0, z: 0 },
           );
-          if (progress < 1) requestAnimationFrame(animate);
+          if (progress < 1) rafId = requestAnimationFrame(animate);
         };
-        requestAnimationFrame(animate);
+        rafId = requestAnimationFrame(animate);
       }, 500);
-
-      return () => clearTimeout(orbitTimer);
     }, delay);
-    return () => clearTimeout(timer);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      if (orbitTimer) clearTimeout(orbitTimer);
+      if (rafId) cancelAnimationFrame(rafId);
+    };
   }, [graphData]);
 
   const handleNodeClick = useCallback(
@@ -711,27 +753,38 @@ export default function ForceGraphView({
     });
   }, []);
 
-  // Dispose and clear node cache when graphData or isDark changes
+  // Refresh the per-node object cache when graphData or isDark changes.
+  //
+  // Node meshes/sprites mix SHARED module-level cached materials/textures
+  // (materialCache, pageTextureCache, labelTextureCache) with per-node materials
+  // created fresh here (segment/cluster/ring/glow/outer meshes, sprite labels).
+  // Dispose ONLY the per-node materials (tagged via markPerNode) so their GPU
+  // memory is freed, while leaving shared cached objects intact for reuse. Never
+  // dispose `.map` — textures are always shared. Shared caches + geometries are
+  // disposed once on unmount below.
+  //
+  // Disposal is DEFERRED to the next frame: force-graph may still be rendering
+  // the previous node objects when this effect runs, so disposing their
+  // materials synchronously could blank a frame. We swap in a fresh cache
+  // immediately (so nodeThreeObject rebuilds) and dispose the old objects once
+  // the new graph has been drawn.
   useEffect(() => {
-    for (const group of nodeObjectCache.current.values()) {
-      group.traverse((child) => {
-        if (child instanceof THREE.Mesh) {
-          if (child.material instanceof THREE.Material) {
-            child.material.dispose();
-          }
-        } else if (child instanceof THREE.Sprite) {
-          child.material?.map?.dispose();
-          child.material?.dispose();
-        }
-      });
-    }
-    nodeObjectCache.current.clear();
+    const stale = nodeObjectCache.current;
+    nodeObjectCache.current = new Map<string, THREE.Group>();
+
+    const rafId = requestAnimationFrame(() => {
+      for (const group of stale.values()) {
+        disposePerNodeMaterials(group);
+      }
+      stale.clear();
+    });
+    return () => cancelAnimationFrame(rafId);
   }, [graphData, isDark]);
 
   // Create 3D node objects (cached per node id)
   const nodeThreeObject = useCallback(
     (node: ForceNode) => {
-      const cacheKey = `${node.id}:${node.matched}:${isDark}`;
+      const cacheKey = `${graphVersion}:${node.id}:${node.matched}:${isDark}`;
       const cached = nodeObjectCache.current.get(cacheKey);
       if (cached) return cached;
 
@@ -747,11 +800,13 @@ export default function ForceGraphView({
           !!node.matched,
           isDark,
         );
-        const mat = new THREE.MeshBasicMaterial({
-          map: texture,
-          transparent: true,
-          side: THREE.DoubleSide,
-        });
+        const mat = markPerNode(
+          new THREE.MeshBasicMaterial({
+            map: texture,
+            transparent: true,
+            side: THREE.DoubleSide,
+          }),
+        );
         mesh = new THREE.Mesh(geo, mat);
         mesh.scale.set(r * 3.5, r * 4.5, 1);
       } else if (node.nodeType === 'analysis') {
@@ -768,22 +823,26 @@ export default function ForceGraphView({
         mesh.scale.set(r * 1.8, r * 3, r * 1.8);
       } else if (node.nodeType === 'cluster') {
         // Large translucent sphere for cluster
-        const clusterMat = new THREE.MeshLambertMaterial({
-          color: new THREE.Color(node.color),
-          transparent: true,
-          opacity: 0.5,
-          emissive: new THREE.Color(node.color),
-          emissiveIntensity: 0.3,
-        });
+        const clusterMat = markPerNode(
+          new THREE.MeshLambertMaterial({
+            color: new THREE.Color(node.color),
+            transparent: true,
+            opacity: 0.5,
+            emissive: new THREE.Color(node.color),
+            emissiveIntensity: 0.3,
+          }),
+        );
         mesh = new THREE.Mesh(geometryCache.sphere, clusterMat);
         mesh.scale.set(r, r, r);
         // Outer glow ring
-        const ringMat = new THREE.MeshBasicMaterial({
-          color: new THREE.Color(node.color),
-          transparent: true,
-          opacity: 0.15,
-          depthWrite: false,
-        });
+        const ringMat = markPerNode(
+          new THREE.MeshBasicMaterial({
+            color: new THREE.Color(node.color),
+            transparent: true,
+            opacity: 0.15,
+            depthWrite: false,
+          }),
+        );
         const ring = new THREE.Mesh(geometryCache.sphere, ringMat);
         ring.scale.set(r * 1.5, r * 1.5, r * 1.5);
         group.add(ring);
@@ -800,12 +859,14 @@ export default function ForceGraphView({
       // Glow effect for matched (searched) nodes — pulsing
       if (node.matched) {
         // Inner glow
-        const glowMat = new THREE.MeshBasicMaterial({
-          color: new THREE.Color(node.color),
-          transparent: true,
-          opacity: 0.4,
-          depthWrite: false,
-        });
+        const glowMat = markPerNode(
+          new THREE.MeshBasicMaterial({
+            color: new THREE.Color(node.color),
+            transparent: true,
+            opacity: 0.4,
+            depthWrite: false,
+          }),
+        );
         const glow = new THREE.Mesh(geometryCache.sphere, glowMat);
         const glowScale = r * 3;
         glow.scale.set(glowScale, glowScale, glowScale);
@@ -814,12 +875,14 @@ export default function ForceGraphView({
         group.add(glow);
 
         // Outer glow (softer, larger)
-        const outerMat = new THREE.MeshBasicMaterial({
-          color: new THREE.Color(node.color),
-          transparent: true,
-          opacity: 0.15,
-          depthWrite: false,
-        });
+        const outerMat = markPerNode(
+          new THREE.MeshBasicMaterial({
+            color: new THREE.Color(node.color),
+            transparent: true,
+            opacity: 0.15,
+            depthWrite: false,
+          }),
+        );
         const outer = new THREE.Mesh(geometryCache.sphere, outerMat);
         const outerScale = r * 5;
         outer.scale.set(outerScale, outerScale, outerScale);
@@ -839,7 +902,7 @@ export default function ForceGraphView({
       nodeObjectCache.current.set(cacheKey, group);
       return group;
     },
-    [isDark],
+    [isDark, graphVersion],
   );
 
   const handleEngineTick = useCallback(() => {

--- a/packages/frontend/src/components/GraphView/TagCloudView.tsx
+++ b/packages/frontend/src/components/GraphView/TagCloudView.tsx
@@ -205,6 +205,7 @@ export default function TagCloudView({
     const minFont = 14;
     const maxFont = Math.min(72, dimensions.width / 8);
 
+    let cancelled = false;
     const layout = cloud()
       .size([dimensions.width, dimensions.height])
       .words(
@@ -221,10 +222,19 @@ export default function TagCloudView({
       .font('sans-serif')
       .fontSize((d) => (d as { size: number }).size)
       .on('end', (output: PlacedWord[]) => {
+        // Ignore a stale layout that finished after unmount / re-run.
+        if (cancelled) return;
         setWords(output);
       });
 
     layout.start();
+
+    // Stop the async layout and drop its late 'end' callback when inputs change
+    // or the component unmounts, so an old layout can't burn CPU or setState.
+    return () => {
+      cancelled = true;
+      layout.stop();
+    };
   }, [tags, dimensions, rotation]);
 
   const handleClick = useCallback(

--- a/packages/frontend/src/components/SidePanel.tsx
+++ b/packages/frontend/src/components/SidePanel.tsx
@@ -400,6 +400,22 @@ function StepProgressBar({
               </div>
             );
           })()}
+
+          {/* Completed-with-warning (e.g. some spreadsheet sheets were skipped
+              but the workflow still completed with the valid ones). */}
+          {(() => {
+            const partial = visibleSteps.filter(
+              ([, s]) => s.status === 'completed' && s.reason,
+            );
+            if (partial.length === 0) return null;
+            return (
+              <div className="mt-1.5 p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/40 rounded text-[10px] text-amber-700 dark:text-amber-400 space-y-0.5">
+                {partial.map(([key, s]) => (
+                  <p key={key}>{s.reason}</p>
+                ))}
+              </div>
+            );
+          })()}
         </div>
       )}
     </div>
@@ -430,6 +446,9 @@ function useVerticalResize(
   });
 
   const dragging = useRef(false);
+  // Track the active drag listeners so they can be removed on unmount even if
+  // the mouseup never fires (e.g. route change / panel unmount mid-drag).
+  const cleanupDragRef = useRef<(() => void) | null>(null);
 
   const onMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -447,10 +466,15 @@ function useVerticalResize(
         setTopRatio(ratio);
       };
 
-      const onMouseUp = () => {
-        dragging.current = false;
+      const removeListeners = () => {
         document.removeEventListener('mousemove', onMouseMove);
         document.removeEventListener('mouseup', onMouseUp);
+        cleanupDragRef.current = null;
+      };
+
+      const onMouseUp = () => {
+        dragging.current = false;
+        removeListeners();
         // Save to localStorage on release
         setTopRatio((r) => {
           try {
@@ -464,9 +488,17 @@ function useVerticalResize(
 
       document.addEventListener('mousemove', onMouseMove);
       document.addEventListener('mouseup', onMouseUp);
+      cleanupDragRef.current = removeListeners;
     },
     [containerRef, minRatio, maxRatio, storageKey],
   );
+
+  // Remove any dangling drag listeners if the component unmounts mid-drag.
+  useEffect(() => {
+    return () => {
+      cleanupDragRef.current?.();
+    };
+  }, []);
 
   return { topRatio, onMouseDown };
 }

--- a/packages/frontend/src/components/WorkflowDetailModal.tsx
+++ b/packages/frontend/src/components/WorkflowDetailModal.tsx
@@ -296,6 +296,18 @@ export default function WorkflowDetailModal({
   const [tagCloudMaxTags, setTagCloudMaxTags] = useState(100);
   const [tagCloudRotation, setTagCloudRotation] = useState(true);
   const [graphRebuilding, setGraphRebuilding] = useState(false);
+  // Deferred post-rebuild refresh timer, tracked so it can be cancelled if the
+  // modal closes during the 5s wait (avoids late fetchGraph/setState).
+  const rebuildTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // False after unmount; guards late async callbacks (segment load, rebuild
+  // timer) from calling setState on an unmounted modal.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
   const [graphPanelSections, setGraphPanelSections] = useState({
     filters: true,
     display: false,
@@ -448,13 +460,24 @@ export default function WorkflowDetailModal({
         { method: 'POST' },
       )
       .then(() => {
-        setTimeout(() => {
+        rebuildTimerRef.current = setTimeout(() => {
+          rebuildTimerRef.current = null;
+          if (!mountedRef.current) return;
           fetchGraph();
           setGraphRebuilding(false);
         }, 5000);
       })
-      .catch(() => setGraphRebuilding(false));
+      .catch(() => {
+        if (mountedRef.current) setGraphRebuilding(false);
+      });
   }, [graphRebuilding, projectId, workflow.document_id, fetchGraph]);
+
+  // Cancel the pending post-rebuild refresh if the modal unmounts mid-wait.
+  useEffect(() => {
+    return () => {
+      if (rebuildTimerRef.current) clearTimeout(rebuildTimerRef.current);
+    };
+  }, []);
 
   const graphLinkTypes = useMemo(() => {
     if (!graphData) return [];
@@ -565,6 +588,26 @@ export default function WorkflowDetailModal({
   const segmentCacheRef = useRef(segmentCache);
   segmentCacheRef.current = segmentCache;
 
+  // Bound the cache so paging through a large document doesn't grow memory
+  // without limit. Map preserves insertion order, so evict oldest entries first,
+  // but never evict the segment currently being viewed.
+  const MAX_SEGMENT_CACHE = 50;
+  const addToCache = useCallback(
+    (prev: Map<number, SegmentData>, index: number, data: SegmentData) => {
+      const next = new Map(prev);
+      next.set(index, data);
+      if (next.size > MAX_SEGMENT_CACHE) {
+        for (const key of next.keys()) {
+          if (next.size <= MAX_SEGMENT_CACHE) break;
+          if (key === index) continue; // keep the just-added one
+          next.delete(key);
+        }
+      }
+      return next;
+    },
+    [],
+  );
+
   const currentSegment = segmentCache.get(currentSegmentIndex) ?? null;
 
   const fetchSegment = useCallback(
@@ -575,18 +618,15 @@ export default function WorkflowDetailModal({
       prefetchingRef.current.add(index);
       try {
         const data = await onLoadSegment(index);
-        setSegmentCache((prev) => {
-          const next = new Map(prev);
-          next.set(index, data);
-          return next;
-        });
+        if (!mountedRef.current) return;
+        setSegmentCache((prev) => addToCache(prev, index, data));
       } catch (e) {
         console.error(`Failed to load segment ${index}:`, e);
       } finally {
         prefetchingRef.current.delete(index);
       }
     },
-    [onLoadSegment],
+    [onLoadSegment, addToCache],
   );
 
   // Reset image zoom and base size on segment change
@@ -633,31 +673,38 @@ export default function WorkflowDetailModal({
     if (prefetchingRef.current.has(currentSegmentIndex)) return;
     prefetchingRef.current.add(currentSegmentIndex);
 
+    // Guard against the response landing after the index changed (effect re-run)
+    // or the modal unmounted: a stale load must not update state. `cancelled` is
+    // flipped by this effect's cleanup when currentSegmentIndex changes.
+    const loadingIndex = currentSegmentIndex;
+    let cancelled = false;
     setSegmentLoading(true);
-    onLoadSegment(currentSegmentIndex)
+    onLoadSegment(loadingIndex)
       .then((data) => {
-        setSegmentCache((prev) => {
-          const next = new Map(prev);
-          next.set(currentSegmentIndex, data);
-          return next;
-        });
+        if (cancelled || !mountedRef.current) return;
+        setSegmentCache((prev) => addToCache(prev, loadingIndex, data));
         setSegmentLoading(false);
         // Prefetch adjacent
-        if (currentSegmentIndex > 0) fetchSegment(currentSegmentIndex - 1);
-        if (currentSegmentIndex < workflow.total_segments - 1)
-          fetchSegment(currentSegmentIndex + 1);
+        if (loadingIndex > 0) fetchSegment(loadingIndex - 1);
+        if (loadingIndex < workflow.total_segments - 1)
+          fetchSegment(loadingIndex + 1);
       })
       .catch((e) => {
-        console.error(`Failed to load segment ${currentSegmentIndex}:`, e);
-        setSegmentLoading(false);
+        console.error(`Failed to load segment ${loadingIndex}:`, e);
+        if (!cancelled && mountedRef.current) setSegmentLoading(false);
       })
       .finally(() => {
-        prefetchingRef.current.delete(currentSegmentIndex);
+        prefetchingRef.current.delete(loadingIndex);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     currentSegmentIndex,
     onLoadSegment,
     fetchSegment,
+    addToCache,
     workflow.total_segments,
   ]);
 

--- a/packages/frontend/src/contexts/WebSocketContext.tsx
+++ b/packages/frontend/src/contexts/WebSocketContext.tsx
@@ -53,6 +53,9 @@ export function WebSocketProvider({ children }: PropsWithChildren) {
   const reconnectAttemptsRef = useRef(0);
   const isManualDisconnectRef = useRef(false);
   const isConnectingRef = useRef(false);
+  // False after the provider unmounts; guards async connect() from creating a
+  // socket or calling setState after teardown (e.g. fast project switches).
+  const mountedRef = useRef(true);
   const subscribersRef = useRef<Map<string, Set<MessageCallback>>>(new Map());
 
   /** Cognito Identity Pool에서 AWS 자격 증명 획득 */
@@ -134,18 +137,29 @@ export function WebSocketProvider({ children }: PropsWithChildren) {
     isManualDisconnectRef.current = false;
     setStatus('connecting');
 
-    const credentials = await getCredentials();
-    console.log('WebSocket credentials:', {
-      accessKeyId: credentials.accessKeyId,
-      hasSessionToken: !!credentials.sessionToken,
-    });
+    let signedUrl: string;
+    try {
+      const credentials = await getCredentials();
+      signedUrl = await createSignedWebSocketUrl({
+        websocketUrl,
+        credentials,
+        region: cognitoProps.region,
+      });
+    } catch (err) {
+      // Signing/credentials failed — reset the flag so future connects aren't
+      // permanently blocked, and don't leave status stuck on 'connecting'.
+      console.error('WebSocket connect failed during signing:', err);
+      isConnectingRef.current = false;
+      if (mountedRef.current) setStatus('error');
+      return;
+    }
 
-    const signedUrl = await createSignedWebSocketUrl({
-      websocketUrl,
-      credentials,
-      region: cognitoProps.region,
-    });
-    console.log('WebSocket signed URL:', signedUrl);
+    // The provider may have unmounted (or a manual disconnect happened) while we
+    // were awaiting signing — abort before creating the socket / touching state.
+    if (!mountedRef.current || isManualDisconnectRef.current) {
+      isConnectingRef.current = false;
+      return;
+    }
 
     const ws = new WebSocket(signedUrl);
     wsRef.current = ws;
@@ -226,6 +240,15 @@ export function WebSocketProvider({ children }: PropsWithChildren) {
   }, []);
 
   /** 자동 연결 */
+  // Track true mount/unmount separately from the (dependency-driven) connect
+  // effect below, so the async connect guard reflects real teardown only.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   useEffect(() => {
     if (user?.id_token && websocketUrl) {
       connect();

--- a/packages/frontend/src/hooks/useAudioCapture.ts
+++ b/packages/frontend/src/hooks/useAudioCapture.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { calculateAudioLevel } from '../lib/audioUtils';
 
 const SAMPLE_RATE = 16000;
@@ -72,6 +72,30 @@ export function useAudioCapture({
   const onAudioLevelRef = useRef(onAudioLevel);
   onAudioChunkRef.current = onAudioChunk;
   onAudioLevelRef.current = onAudioLevel;
+  // False after unmount; startCapture checks it after its awaits so a mic
+  // stream/context acquired late (after cleanup ran) is released, not leaked.
+  const mountedRef = useRef(true);
+
+  // Release audio resources (RAF/worklet/AudioContext/MediaStream). Extracted so
+  // startCapture (on failure), stopCapture, and the unmount cleanup can run it;
+  // does NOT touch state.
+  const releaseResources = useCallback(() => {
+    if (animFrameRef.current) {
+      cancelAnimationFrame(animFrameRef.current);
+      animFrameRef.current = 0;
+    }
+
+    workletNodeRef.current?.disconnect();
+    workletNodeRef.current = null;
+
+    audioContextRef.current?.close();
+    audioContextRef.current = null;
+
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+
+    analyserRef.current = null;
+  }, []);
 
   const startCapture = useCallback(async () => {
     if (audioContextRef.current) return;
@@ -84,16 +108,38 @@ export function useAudioCapture({
         noiseSuppression: true,
       },
     });
+    // Unmounted while getUserMedia was pending — stop the stream and bail.
+    if (!mountedRef.current) {
+      stream.getTracks().forEach((t) => t.stop());
+      return;
+    }
     streamRef.current = stream;
 
     const audioContext = new AudioContext({ sampleRate: SAMPLE_RATE });
     audioContextRef.current = audioContext;
 
-    // Register the worklet processor
+    // Register the worklet processor. Revoke the object URL even if addModule
+    // throws, and on failure release the already-acquired mic stream + audio
+    // context (they'd otherwise leak since the exception propagates).
     const blob = new Blob([workletCode], { type: 'application/javascript' });
     const workletUrl = URL.createObjectURL(blob);
-    await audioContext.audioWorklet.addModule(workletUrl);
-    URL.revokeObjectURL(workletUrl);
+    try {
+      await audioContext.audioWorklet.addModule(workletUrl);
+    } catch (err) {
+      releaseResources();
+      throw err;
+    } finally {
+      URL.revokeObjectURL(workletUrl);
+    }
+
+    // Unmounted while the worklet module was loading — release and bail.
+    if (!mountedRef.current) {
+      audioContext.close();
+      audioContextRef.current = null;
+      stream.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+      return;
+    }
 
     const source = audioContext.createMediaStreamSource(stream);
 
@@ -130,27 +176,23 @@ export function useAudioCapture({
     updateLevel();
 
     setIsCapturing(true);
-  }, []);
+  }, [releaseResources]);
 
   const stopCapture = useCallback(() => {
-    if (animFrameRef.current) {
-      cancelAnimationFrame(animFrameRef.current);
-      animFrameRef.current = 0;
-    }
-
-    workletNodeRef.current?.disconnect();
-    workletNodeRef.current = null;
-
-    audioContextRef.current?.close();
-    audioContextRef.current = null;
-
-    streamRef.current?.getTracks().forEach((t) => t.stop());
-    streamRef.current = null;
-
-    analyserRef.current = null;
+    releaseResources();
     setIsCapturing(false);
     setAudioLevel(0);
-  }, []);
+  }, [releaseResources]);
+
+  // Always release audio resources on unmount, even if the consumer forgets to
+  // call stopCapture (prevents leaked MediaStream/AudioContext/RAF).
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      releaseResources();
+    };
+  }, [releaseResources]);
 
   return { isCapturing, startCapture, stopCapture, audioLevel };
 }

--- a/packages/frontend/src/hooks/useAudioPlayback.ts
+++ b/packages/frontend/src/hooks/useAudioPlayback.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { calculateAudioLevel } from '../lib/audioUtils';
 
 function base64ToInt16Array(base64: string): Int16Array {
@@ -107,7 +107,9 @@ export function useAudioPlayback(): UseAudioPlaybackReturn {
     [getAudioContext, isPlaying, startLevelMeter, stopLevelMeter],
   );
 
-  const stop = useCallback(() => {
+  // Release the AudioContext/RAF without touching state; shared by stop() and
+  // the unmount cleanup.
+  const releaseResources = useCallback(() => {
     if (audioContextRef.current && audioContextRef.current.state !== 'closed') {
       audioContextRef.current.close();
     }
@@ -115,9 +117,25 @@ export function useAudioPlayback(): UseAudioPlaybackReturn {
     analyserRef.current = null;
     nextStartTimeRef.current = 0;
     activeSourcesRef.current = 0;
+    if (animFrameRef.current) {
+      cancelAnimationFrame(animFrameRef.current);
+      animFrameRef.current = 0;
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    releaseResources();
     setIsPlaying(false);
-    stopLevelMeter();
-  }, [stopLevelMeter]);
+    setAudioLevel(0);
+  }, [releaseResources]);
+
+  // Always release the AudioContext/RAF on unmount, even if stop() was never
+  // called (prevents leaked AudioContext / animation frames).
+  useEffect(() => {
+    return () => {
+      releaseResources();
+    };
+  }, [releaseResources]);
 
   return { isPlaying, enqueueAudio, stop, audioLevel };
 }

--- a/packages/frontend/src/hooks/useAwsClient.ts
+++ b/packages/frontend/src/hooks/useAwsClient.ts
@@ -109,67 +109,83 @@ export interface ContentBlock {
 async function parseStream(
   response: Response,
   onEvent?: (event: StreamEvent) => void,
+  signal?: AbortSignal,
 ): Promise<string> {
   const reader = response.body?.getReader();
   if (!reader) throw new Error('No response body');
+
+  // Cancel the reader if the caller aborts (user pressed Stop). This closes the
+  // HTTP stream, which the agent runtime turns into a cancellation of the
+  // in-progress agent invocation.
+  const onAbort = () => {
+    reader.cancel().catch(() => undefined);
+  };
+  if (signal) {
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  }
 
   const decoder = new TextDecoder();
   let result = '';
   let buffer = '';
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
 
-    buffer += decoder.decode(value, { stream: true });
+      buffer += decoder.decode(value, { stream: true });
 
-    // JSON 객체 단위로 파싱
-    let startIdx = 0;
-    for (let i = 0; i < buffer.length; i++) {
-      if (buffer[i] === '{') {
-        let braceCount = 1;
-        let j = i + 1;
-        let inString = false;
-        let escape = false;
-        while (j < buffer.length && braceCount > 0) {
-          const ch = buffer[j];
-          if (escape) {
-            escape = false;
-          } else if (ch === '\\') {
-            escape = true;
-          } else if (ch === '"') {
-            inString = !inString;
-          } else if (!inString) {
-            if (ch === '{') braceCount++;
-            else if (ch === '}') braceCount--;
-          }
-          j++;
-        }
-        if (braceCount === 0) {
-          const jsonStr = buffer.slice(i, j);
-          try {
-            const event = JSON.parse(jsonStr) as StreamEvent;
-            onEvent?.(event);
-            if (
-              event.type === 'text' &&
-              event.content &&
-              typeof event.content === 'string'
-            ) {
-              result += event.content;
+      // JSON 객체 단위로 파싱
+      let startIdx = 0;
+      for (let i = 0; i < buffer.length; i++) {
+        if (buffer[i] === '{') {
+          let braceCount = 1;
+          let j = i + 1;
+          let inString = false;
+          let escape = false;
+          while (j < buffer.length && braceCount > 0) {
+            const ch = buffer[j];
+            if (escape) {
+              escape = false;
+            } else if (ch === '\\') {
+              escape = true;
+            } else if (ch === '"') {
+              inString = !inString;
+            } else if (!inString) {
+              if (ch === '{') braceCount++;
+              else if (ch === '}') braceCount--;
             }
-          } catch {
-            // JSON 파싱 실패 시 무시
+            j++;
           }
-          startIdx = j;
-          i = j - 1;
-        } else {
-          // 불완전한 JSON - 다음 chunk에서 완성될 때까지 버퍼에 유지
-          startIdx = i;
-          break;
+          if (braceCount === 0) {
+            const jsonStr = buffer.slice(i, j);
+            try {
+              const event = JSON.parse(jsonStr) as StreamEvent;
+              onEvent?.(event);
+              if (
+                event.type === 'text' &&
+                event.content &&
+                typeof event.content === 'string'
+              ) {
+                result += event.content;
+              }
+            } catch {
+              // JSON 파싱 실패 시 무시
+            }
+            startIdx = j;
+            i = j - 1;
+          } else {
+            // 불완전한 JSON - 다음 chunk에서 완성될 때까지 버퍼에 유지
+            startIdx = i;
+            break;
+          }
         }
       }
+      buffer = buffer.slice(startIdx);
     }
-    buffer = buffer.slice(startIdx);
+  } finally {
+    if (signal) signal.removeEventListener('abort', onAbort);
   }
 
   return result;
@@ -307,6 +323,7 @@ export function useAwsClient() {
       onEvent?: (event: StreamEvent) => void,
       agentId?: string,
       runtimeArn?: string,
+      signal?: AbortSignal,
     ): Promise<string> => {
       const targetArn = runtimeArn || agentRuntimeArn;
       if (!targetArn) throw new Error('Agent runtime ARN not available');
@@ -330,6 +347,9 @@ export function useAwsClient() {
             user_id: user.profile?.['cognito:username'] as string,
             agent_id: agentId,
           }),
+          // Aborting closes the HTTP stream, which the agent runtime turns into
+          // a cancellation of the in-progress invocation.
+          signal,
         },
       );
 
@@ -343,7 +363,7 @@ export function useAwsClient() {
         ?.includes('text/event-stream');
 
       if (isStreaming) {
-        return parseStream(response, onEvent);
+        return parseStream(response, onEvent, signal);
       }
 
       return JSON.stringify(await response.json());

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -86,6 +86,8 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
   const forceNewTextBlockRef = useRef(false);
   const chatScrollPositionRef = useRef(0);
   const streamingBlocksRef = useRef<StreamingBlock[]>([]);
+  // Controls the in-flight agent request so the user can stop generation.
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const loadSessions = useCallback(async () => {
     try {
@@ -935,12 +937,17 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
           contentBlocks.push({ text: userMessage.content });
         }
 
+        const abortController = new AbortController();
+        abortControllerRef.current = abortController;
+
         await invokeAgent(
           contentBlocks,
           currentSessionId,
           projectId,
           handleStreamEvent,
           selectedAgent?.agent_id,
+          undefined,
+          abortController.signal,
         );
 
         // pending has all messages in order (text + tool_result + stage)
@@ -954,21 +961,31 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
 
         setMessages((prev) => [...prev, ...pending]);
       } catch (error) {
-        console.error('Failed to send message:', error);
-        // Preserve any content accumulated before the error
+        // Preserve any content accumulated before the error/stop
         let partial = pendingMessagesRef.current;
         pendingMessagesRef.current = [];
         if (partial.length === 0 && streamingBlocksRef.current.length > 0) {
           partial = blocksToMessages(streamingBlocksRef.current);
         }
-        const errorMessage: ChatMessage = {
-          id: crypto.randomUUID(),
-          role: 'assistant',
-          content: `Failed to get response: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          timestamp: new Date(),
-        };
-        setMessages((prev) => [...prev, ...partial, errorMessage]);
+
+        // User pressed Stop: keep the partial response, no error bubble.
+        const isAbort =
+          abortControllerRef.current?.signal.aborted ||
+          (error instanceof DOMException && error.name === 'AbortError');
+        if (isAbort) {
+          setMessages((prev) => [...prev, ...partial]);
+        } else {
+          console.error('Failed to send message:', error);
+          const errorMessage: ChatMessage = {
+            id: crypto.randomUUID(),
+            role: 'assistant',
+            content: `Failed to get response: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            timestamp: new Date(),
+          };
+          setMessages((prev) => [...prev, ...partial, errorMessage]);
+        }
       }
+      abortControllerRef.current = null;
       setSending(false);
       setStreamingBlocks([]);
       streamingBlocksRef.current = [];
@@ -984,6 +1001,13 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
       loadSessions,
     ],
   );
+
+  // Stop the in-flight response. Aborting closes the HTTP stream, which the
+  // agent runtime turns into a graceful cancellation; the partial response is
+  // kept (handled in handleSendMessage's catch).
+  const stopStreaming = useCallback(() => {
+    abortControllerRef.current?.abort();
+  }, []);
 
   return {
     currentSessionId,
@@ -1011,5 +1035,6 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
     handleSessionDelete,
     handleStreamEvent,
     handleSendMessage,
+    stopStreaming,
   };
 }

--- a/packages/frontend/src/hooks/useDocuments.ts
+++ b/packages/frontend/src/hooks/useDocuments.ts
@@ -72,6 +72,18 @@ export function useDocuments({
   const [showUploadModal, setShowUploadModal] = useState(false);
   const progressFetchedRef = useRef(false);
   const loadDocumentsTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  // Track deferred timers from WebSocket status events so they can all be
+  // cancelled on unmount / project switch (otherwise late fetches fire stale).
+  const deferredTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(
+    new Set(),
+  );
+  const deferTimer = useCallback((fn: () => void, delayMs: number) => {
+    const id = setTimeout(() => {
+      deferredTimersRef.current.delete(id);
+      fn();
+    }, delayMs);
+    deferredTimersRef.current.add(id);
+  }, []);
 
   const loadDocuments = useCallback(async () => {
     try {
@@ -359,7 +371,7 @@ export function useDocuments({
           debouncedLoadDocuments();
 
           // Fetch step progress after a short delay so the API has data
-          setTimeout(() => {
+          deferTimer(() => {
             fetchProgressRef.current();
           }, 2000);
         } else if (data.status === 'reanalyzing') {
@@ -388,7 +400,7 @@ export function useDocuments({
             ),
           );
 
-          setTimeout(() => {
+          deferTimer(() => {
             fetchProgressRef.current();
           }, 2000);
         } else if (
@@ -410,14 +422,21 @@ export function useDocuments({
             };
           });
 
-          setTimeout(() => {
+          deferTimer(() => {
             loadDocuments();
             loadWorkflows();
           }, 1500);
         }
       }
     },
-    [projectId, loadDocuments, loadWorkflows, debouncedLoadDocuments, t],
+    [
+      projectId,
+      loadDocuments,
+      loadWorkflows,
+      debouncedLoadDocuments,
+      deferTimer,
+      t,
+    ],
   );
 
   useWebSocketMessage('workflow', handleWorkflowMessage);
@@ -492,22 +511,40 @@ export function useDocuments({
     [workflows],
   );
 
-  // Handle workflow completion/failure - clear completed/failed after delay
+  // Handle workflow completion/failure - clear completed/failed after delay.
+  // Refresh once per completed workflow: without this, any change to
+  // workflowProgressMap (e.g. another workflow's progress) would re-trigger a
+  // full loadDocuments/loadWorkflows while completed entries linger in the map.
+  const refreshedCompletionsRef = useRef<Set<string>>(new Set());
+  // Reset the completion dedupe set when the project changes so it can't grow
+  // unbounded across a long-lived session spanning many projects/documents.
   useEffect(() => {
-    const completedDocIds = Object.entries(workflowProgressMap)
-      .filter(
-        ([, progress]) =>
-          (progress.status === 'completed' ||
-            progress.status === 'failed' ||
-            progress.status === 'needs_user_fix') &&
-          progress.qaRegen?.status !== 'in_progress',
-      )
-      .map(([docId]) => docId);
+    refreshedCompletionsRef.current = new Set();
+  }, [projectId]);
+  useEffect(() => {
+    const completed = Object.entries(workflowProgressMap).filter(
+      ([, progress]) =>
+        (progress.status === 'completed' ||
+          progress.status === 'failed' ||
+          progress.status === 'needs_user_fix') &&
+        progress.qaRegen?.status !== 'in_progress',
+    );
 
-    if (completedDocIds.length === 0) return;
+    // Only act on completions not already refreshed (keyed by doc+workflow so a
+    // re-analysis with a new workflow_id refreshes again).
+    const fresh = completed.filter(
+      ([docId, p]) =>
+        !refreshedCompletionsRef.current.has(`${docId}:${p.workflowId}`),
+    );
+    if (fresh.length === 0) return;
+
+    for (const [docId, p] of fresh) {
+      refreshedCompletionsRef.current.add(`${docId}:${p.workflowId}`);
+    }
 
     loadDocumentsRef.current();
     loadWorkflowsRef.current();
+    const completedDocIds = fresh.map(([docId]) => docId);
     const timeout = setTimeout(() => {
       setWorkflowProgressMap((prev) => {
         const newMap = { ...prev };
@@ -544,12 +581,15 @@ export function useDocuments({
     });
   }, [documents]);
 
-  // Clean up debounce timer on unmount
+  // Clean up debounce timer and any deferred WebSocket-event timers on unmount
   useEffect(() => {
+    const deferred = deferredTimersRef.current;
     return () => {
       if (loadDocumentsTimerRef.current) {
         clearTimeout(loadDocumentsTimerRef.current);
       }
+      for (const id of deferred) clearTimeout(id);
+      deferred.clear();
     };
   }, []);
 

--- a/packages/frontend/src/hooks/useVoiceChat.ts
+++ b/packages/frontend/src/hooks/useVoiceChat.ts
@@ -91,6 +91,10 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
     new Set(),
   );
   const pendingDisconnectReasonRef = useRef<DisconnectReason>(null);
+  // Monotonic connect id: bumped on each connect/disconnect/unmount so an
+  // in-flight connect (awaiting credentials/signing) can detect it is stale and
+  // abort before creating a socket / calling setState / starting capture.
+  const connectSeqRef = useRef(0);
 
   const playback = useAudioPlayback();
 
@@ -112,6 +116,8 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
 
   const disconnect = useCallback(
     (reason: DisconnectReason = 'user') => {
+      // Invalidate any in-flight connect so its post-await code aborts.
+      connectSeqRef.current += 1;
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
@@ -154,6 +160,7 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
         return;
       }
 
+      const seq = ++connectSeqRef.current;
       setState((s) => ({ ...s, status: 'connecting', disconnectReason: null }));
       console.log('[VoiceChat] status set to connecting');
 
@@ -174,11 +181,24 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
           service: 'bedrock-agentcore',
         });
 
+        // Aborted while awaiting credentials/signing (unmount, disconnect, or a
+        // newer connect) — don't create a socket or touch state.
+        if (seq !== connectSeqRef.current) {
+          console.log('[VoiceChat] connect superseded, aborting');
+          return;
+        }
+
         console.log('[VoiceChat] Creating WebSocket...');
         const ws = new WebSocket(signedUrl);
         wsRef.current = ws;
 
         ws.onopen = () => {
+          // Ignore events from a socket that has been superseded (disconnect /
+          // model change / newer connect) before it opened.
+          if (seq !== connectSeqRef.current || wsRef.current !== ws) {
+            ws.close();
+            return;
+          }
           console.log('[VoiceChat] WebSocket opened');
           // Send config as first message
           const config = {
@@ -208,6 +228,12 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
           capture
             .startCapture()
             .then(() => {
+              // Disconnected / superseded while getUserMedia was pending — undo
+              // the capture we just started instead of flipping isListening on.
+              if (seq !== connectSeqRef.current) {
+                capture.stopCapture();
+                return;
+              }
               console.log('[VoiceChat] Mic capture started successfully');
               setState((s) => ({ ...s, isListening: true }));
             })
@@ -230,6 +256,9 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
         };
 
         ws.onmessage = (event) => {
+          // Drop messages from a stale/superseded socket so late audio/state
+          // from an old session isn't applied.
+          if (seq !== connectSeqRef.current || wsRef.current !== ws) return;
           messageCountRef.current += 1;
           try {
             const data = JSON.parse(event.data);
@@ -329,6 +358,9 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
         };
 
         ws.onerror = (err) => {
+          // A superseded socket's error must not flip the current session to
+          // 'error'.
+          if (seq !== connectSeqRef.current || wsRef.current !== ws) return;
           console.log('[VoiceChat] WebSocket error:', err);
           setState((s) => ({ ...s, status: 'error' }));
         };
@@ -363,6 +395,8 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
         };
       } catch (err) {
         console.log('[VoiceChat] Connect error:', err);
+        // Don't surface an error for a connect that was already superseded.
+        if (seq !== connectSeqRef.current) return;
         setState({
           status: 'error',
           isListening: false,
@@ -434,9 +468,19 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
     };
   }, []);
 
-  // Cleanup on unmount
+  // Keep latest capture/playback stop fns in refs so the unmount cleanup can
+  // call them without depending on the (per-render) hook objects.
+  const stopCaptureRef = useRef(capture.stopCapture);
+  const stopPlaybackRef = useRef(playback.stop);
+  stopCaptureRef.current = capture.stopCapture;
+  stopPlaybackRef.current = playback.stop;
+
+  // Cleanup on unmount: close the socket/timers AND stop audio capture/playback
+  // so mic MediaStream + AudioContext are released when the voice UI closes.
   useEffect(() => {
     return () => {
+      // Invalidate any in-flight connect awaiting credentials/signing.
+      connectSeqRef.current += 1;
       if (wsRef.current) {
         wsRef.current.close();
         wsRef.current = null;
@@ -447,6 +491,8 @@ export function useVoiceChat(options: UseVoiceChatOptions): UseVoiceChatReturn {
       if (pingIntervalRef.current) {
         clearInterval(pingIntervalRef.current);
       }
+      stopCaptureRef.current();
+      stopPlaybackRef.current();
     };
   }, []);
 

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -460,7 +460,8 @@
     "graphSearching": "Searching graph",
     "graphSourcesFound": "{{count}} additional pages discovered",
     "graphNoAdditionalSources": "No additional pages discovered",
-    "viewGraph": "View graph"
+    "viewGraph": "View graph",
+    "stop": "Stop"
   },
   "viewer": {
     "zoomIn": "Zoom In",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -460,7 +460,8 @@
     "graphSearching": "グラフ検索中",
     "graphSourcesFound": "追加発見ページ {{count}}件",
     "graphNoAdditionalSources": "追加発見ページなし",
-    "viewGraph": "グラフを見る"
+    "viewGraph": "グラフを見る",
+    "stop": "停止"
   },
   "viewer": {
     "zoomIn": "拡大",

--- a/packages/frontend/src/i18n/locales/ko.json
+++ b/packages/frontend/src/i18n/locales/ko.json
@@ -460,7 +460,8 @@
     "graphSearching": "그래프 검색 중",
     "graphSourcesFound": "추가 발견된 페이지 {{count}}건",
     "graphNoAdditionalSources": "추가 발견된 페이지 없음",
-    "viewGraph": "그래프 보기"
+    "viewGraph": "그래프 보기",
+    "stop": "중지"
   },
   "viewer": {
     "zoomIn": "확대",

--- a/packages/frontend/src/lib/fileTypeUtils.ts
+++ b/packages/frontend/src/lib/fileTypeUtils.ts
@@ -18,6 +18,7 @@ export const TEXT_MIME_TYPES = [
   'text/plain',
   'text/markdown',
   'text/csv',
+  'text/tab-separated-values',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -96,6 +97,7 @@ export const FILE_TYPE_LABELS: Record<string, string> = {
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'XLSX',
   'application/vnd.ms-excel': 'XLS',
   'text/csv': 'CSV',
+  'text/tab-separated-values': 'TSV',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
     'DOCX',
   'application/msword': 'DOC',
@@ -131,7 +133,8 @@ export const getFileTypeCategory = (fileType: string): string => {
   if (
     fileType.includes('spreadsheetml') ||
     fileType.includes('ms-excel') ||
-    fileType === 'text/csv'
+    fileType === 'text/csv' ||
+    fileType === 'text/tab-separated-values'
   )
     return 'spreadsheet';
   if (fileType.includes('presentationml') || fileType.includes('ms-powerpoint'))
@@ -200,7 +203,8 @@ export function getFileIconComponent(fileType: string): {
   if (
     fileType.includes('spreadsheetml') ||
     fileType.includes('ms-excel') ||
-    fileType === 'text/csv'
+    fileType === 'text/csv' ||
+    fileType === 'text/tab-separated-values'
   )
     return { icon: FileSpreadsheet, className: 'h-5 w-5 text-green-400' };
   if (fileType === 'text/markdown')
@@ -235,6 +239,7 @@ export const getFileTypeInfo = (
     case 'xls':
     case 'xlsx':
     case 'csv':
+    case 'tsv':
       return {
         icon: FileSpreadsheet,
         color: 'text-green-500',
@@ -281,6 +286,7 @@ const MIME_TO_EXTENSION: Record<string, string> = {
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
   'application/vnd.ms-excel': 'xls',
   'text/csv': 'csv',
+  'text/tab-separated-values': 'tsv',
   'text/plain': 'txt',
   'text/markdown': 'md',
   'image/png': 'png',

--- a/packages/frontend/src/routes/projects/$projectId.tsx
+++ b/packages/frontend/src/routes/projects/$projectId.tsx
@@ -352,6 +352,7 @@ function ProjectDetailPage() {
                 documents={documentsHook.documents}
                 onInputChange={chatSession.setInputMessage}
                 onSendMessage={handleSendMessage}
+                onStop={chatSession.stopStreaming}
                 onAgentSelect={agentsHook.handleAgentSelect}
                 onAgentClick={() => agentsHook.setShowAgentModal(true)}
                 onNewChat={handleNewSession}

--- a/packages/infra/src/functions/step-functions/dataset-process/index.py
+++ b/packages/infra/src/functions/step-functions/dataset-process/index.py
@@ -267,10 +267,22 @@ def handler(event: dict, context) -> dict:
         )
         created.append({"dataset_id": dataset_id, "dataset_s3_uri": parquet_uri, "rows": int(len(df))})
 
+    # Surface partially-skipped sheets to the user. Even though the workflow is
+    # completed (at least one sheet succeeded), the UI should show which sheets
+    # were excluded and why, rather than silently dropping them.
+    skipped_reason = ""
+    if failures:
+        skipped_reason = (
+            f"{len(created)}개 시트만 처리되었습니다. "
+            f"{len(failures)}개 시트는 정형 데이터로 변환할 수 없어 제외되었습니다: "
+            + _format_failures(failures)
+        )
     record_step_complete(
         workflow_id, StepName.DATASET_PROCESS,
         dataset_count=len(created),
         skipped_sheets=len(failures),
+        reason=skipped_reason,
+        skipped_detail=failures,
     )
     update_workflow_status(
         document_id, workflow_id, WorkflowStatus.COMPLETED, entity_type,

--- a/packages/infra/src/prompts/chat/system_prompt.txt
+++ b/packages/infra/src/prompts/chat/system_prompt.txt
@@ -57,10 +57,15 @@ You can query two kinds of data. Choose based on the question:
 
 ### Using structured data tools (Text2SQL)
 1. Call `search_datasets` with a description of the data you need to find relevant datasets (projects may have many).
-2. Call `describe_dataset` to learn its columns, types, and enum values BEFORE writing SQL.
-   The reference document is the source of truth — do NOT invent column names or values.
-3. Call `run_sql` with a read-only DuckDB query. The dataset is exposed as the table `data`
-   (always query `FROM data`). Only SELECT/WITH is allowed.
+2. Call `describe_dataset` for each dataset you plan to query, to learn its columns, types,
+   enum values, AND its `table_name` BEFORE writing SQL. The reference document is the source
+   of truth — do NOT invent column names or values. Columns are snake_case.
+3. Call `run_sql` with a read-only DuckDB query (SELECT/WITH only):
+   - Single dataset: pass `dataset_uri`; the table is named `data` (query `FROM data`).
+   - Multiple datasets / multi-sheet JOIN: pass `dataset_uris` (a list of the dataset URIs
+     your query touches) and reference each by its `table_name` from `describe_dataset`
+     (e.g. `FROM t_aaa a JOIN t_bbb b ON a.material = b.material`). Include EVERY dataset the
+     SQL uses in `dataset_uris`.
 4. Base the answer only on query results; show the SQL you used in a code block.
 
 ### Cross questions (span both)

--- a/packages/lambda/data-mcp/index.py
+++ b/packages/lambda/data-mcp/index.py
@@ -164,47 +164,81 @@ def _query_datasets(project_id: str) -> list[dict]:
     return result.get("Items", [])
 
 
+def _dataset_entry(dataset_uri: str, name, description) -> dict:
+    return {
+        "dataset_uri": dataset_uri,
+        "table_name": table_name_for(dataset_uri) if dataset_uri else None,
+        "name": name,
+        "description": description or "",
+    }
+
+
+def _all_datasets_from_ddb(project_id: str) -> list[dict]:
+    """Fallback dataset list from DDB DATASET# items (source of truth).
+
+    Used when the LanceDB catalog is empty or unavailable (e.g. catalog indexing
+    failed): the dataset still exists in DDB/Parquet, so it must remain
+    discoverable even without hybrid search.
+    """
+    datasets = []
+    for item in _query_datasets(project_id):
+        data = item.get("data", {})
+        datasets.append(
+            _dataset_entry(
+                data.get("dataset_s3_uri"),
+                data.get("name"),
+                data.get("description", ""),
+            )
+        )
+    return datasets
+
+
 def search_datasets(event: dict) -> dict:
     """Find datasets relevant to a query via hybrid search over the per-project
     catalog (LanceDB). Returns the top matches with their table_name for run_sql.
 
     Replaces listing all datasets: with many datasets, returning the full list
     wastes tokens and hurts selection. The catalog is populated by dataset-process
-    at conversion time.
+    at conversion time. If the catalog is empty or the search fails, falls back to
+    listing all datasets from DDB so datasets stay discoverable.
     """
     project_id = event["project_id"]
     query = event.get("query", "")
 
-    resp = _lambda.invoke(
-        FunctionName=LANCEDB_FUNCTION_ARN,
-        InvocationType="RequestResponse",
-        Payload=json.dumps(
-            {
-                "action": "search_datasets",
-                "params": {
-                    "project_id": project_id,
-                    "query": query,
-                    "limit": SEARCH_DATASETS_LIMIT,
-                },
-            }
-        ),
-    )
-    payload = resp["Payload"].read().decode("utf-8")
-    if "FunctionError" in resp:
-        return {"error": f"Dataset search failed: {payload}"}
-
-    result = json.loads(payload)
-    datasets = []
-    for r in result.get("results", []):
-        dataset_uri = r.get("dataset_s3_uri")
-        datasets.append(
-            {
-                "dataset_uri": dataset_uri,
-                "table_name": table_name_for(dataset_uri) if dataset_uri else None,
-                "name": r.get("name"),
-                "description": r.get("description", ""),
-            }
+    try:
+        resp = _lambda.invoke(
+            FunctionName=LANCEDB_FUNCTION_ARN,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(
+                {
+                    "action": "search_datasets",
+                    "params": {
+                        "project_id": project_id,
+                        "query": query,
+                        "limit": SEARCH_DATASETS_LIMIT,
+                    },
+                }
+            ),
         )
+        payload = resp["Payload"].read().decode("utf-8")
+        if "FunctionError" in resp:
+            raise RuntimeError(payload)
+        result = json.loads(payload)
+        hits = result.get("results", [])
+    except Exception as e:  # noqa: BLE001 - fall back to DDB on any search failure
+        print(f"search_datasets: catalog search failed, falling back to DDB: {e}")
+        return {"datasets": _all_datasets_from_ddb(project_id), "fallback": True}
+
+    datasets = [
+        _dataset_entry(r.get("dataset_s3_uri"), r.get("name"), r.get("description", ""))
+        for r in hits
+    ]
+    # Catalog returned nothing (e.g. indexing not yet run / failed) but datasets
+    # may still exist in DDB -> fall back so they remain discoverable.
+    if not datasets:
+        ddb_datasets = _all_datasets_from_ddb(project_id)
+        if ddb_datasets:
+            return {"datasets": ddb_datasets, "fallback": True}
     return {"datasets": datasets}
 
 
@@ -354,13 +388,26 @@ _FORBIDDEN_RE = re.compile(
     r"pragma|set|export|import|call)\b",
     re.IGNORECASE,
 )
+# Block DuckDB table/scan functions that read arbitrary files or external data
+# (e.g. read_csv('/etc/passwd'), read_parquet('s3://other/...'), glob('/**')).
+# Even without httpfs, these expose the Lambda's local filesystem. The registered
+# views (data / t_*) are the only intended data sources, so any function call of
+# the form name(...) matching these is rejected.
+_FORBIDDEN_FUNC_RE = re.compile(
+    r"\b(read_csv|read_csv_auto|read_parquet|parquet_scan|read_json|read_json_auto|"
+    r"read_ndjson|read_ndjson_auto|read_text|read_blob|glob|sniff_csv|"
+    r"delta_scan|iceberg_scan|postgres_scan|sqlite_scan|mysql_scan|"
+    r"read_xlsx|scan_arrow|arrow_scan|query_table|query)\s*\(",
+    re.IGNORECASE,
+)
 # Match single- or double-quoted string literals so forbidden keywords inside
 # them (e.g. WHERE name = 'update me') are not treated as statements.
 _STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
 
 
 def _is_read_only(query: str) -> bool:
-    """Allow only single SELECT/WITH statements; reject DDL/DML and multi-statements."""
+    """Allow only single SELECT/WITH statements; reject DDL/DML, multi-statements,
+    and file/external table functions."""
     stripped = query.strip().rstrip(";")
     if not _READ_ONLY_RE.match(stripped):
         return False
@@ -370,6 +417,8 @@ def _is_read_only(query: str) -> bool:
     if ";" in without_strings:
         return False
     if _FORBIDDEN_RE.search(without_strings):
+        return False
+    if _FORBIDDEN_FUNC_RE.search(without_strings):
         return False
     return True
 


### PR DESCRIPTION
  - 챗봇 응답 중지 기능 추가: 프론트 AbortController로 스트림 중단 + idp-agent가 disconnect 시 agent.cancel() 호출 (세션 정합성 유지되어 이어서 대화 가능)
  - 중지 버튼 UI: 응답 중 전송 버튼이 회색 정지 버튼으로 토글 (chat.stop i18n)
  - 음성 훅 리소스 정리 강화: useAudioCapture/Playback unmount cleanup, connectSeq/mountedRef로 stale race 차단, worklet 로딩 실패 시 정리
  - WebSocketContext connect race 방지: mountedRef 가드 + 실패 시 isConnecting 리셋
  - WorkflowDetailModal: 세그먼트 캐시 LRU 제한 + async 로드 취소 가드 + rebuild timer 정리
  - ForceGraphView3D: 공유 GPU 캐시 중복 dispose 방지(per-node 태깅), graphVersion 캐시키, orbit 애니메이션 cleanup
  - DatasetView: 쿼리 응답 race 가드(requestSeq), CodeMirror extensions 메모이제이션
  - TagCloud/SidePanel: d3-cloud layout stop, drag 리스너 unmount 정리
  - useDocuments: WebSocket 이벤트 setTimeout 추적/정리, 완료 상태 refetch 1회 제한
  - data-mcp SQL 가드에 table function(read_csv/read_parquet 등) 차단, 카탈로그 검색 실패 시 DDB fallback
  - dataset-process: 일부 시트 제외 시 사유를 step에 기록(UI 경고 노출)
  - idp-agent 프롬프트에 멀티시트 JOIN(dataset_uris/table_name) 규칙 반영
  - TSV 파일 UI 매핑 보강(라벨/카테고리/아이콘/확장자)