### PR TITLE
feat(chat): add model selector, inline charts, question cards, and st…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "private": true,
   "dependencies": {
     "@ark-ui/react": "^5.37.2",
+    "@base-ui/react": "^1.6.0",
     "@aws-cdk/aws-elasticache-alpha": "2.235.1-alpha.0",
     "@aws-cdk/aws-lambda-python-alpha": "2.235.1-alpha.0",
     "@aws-crypto/sha256-browser": "^5.2.0",

--- a/packages/agents/idp-agent/agents/idp_agent.py
+++ b/packages/agents/idp-agent/agents/idp_agent.py
@@ -1,7 +1,11 @@
+import json
+import time
 from contextlib import ExitStack, contextmanager
 
 import boto3
 from botocore.config import Config as BotocoreConfig
+from botocore.exceptions import BotoCoreError, ClientError
+from pydantic import BaseModel
 from strands import Agent, AgentSkills
 from strands.hooks.registry import HookProvider
 from strands.models import BedrockModel
@@ -14,6 +18,8 @@ from config import get_config
 from helpers import get_project_language
 from prompts import build_system_prompt
 from tools.artifact import create_artifact_path_tool
+from tools.ask import ask_user
+from tools.charts import render_chart
 
 from .image_artifact_saver_hook import ImageArtifactSaverHook
 from .syntax_check_hook import SyntaxCheckHook
@@ -57,12 +63,128 @@ def get_mcp_client():
     )
 
 
+# SSM parameter holding the chat model catalog. Used here as the allowlist of
+# model IDs a client may request; the frontend selector is a UI, not a security
+# boundary, so a tampered request must still be validated server-side.
+MODEL_CATALOG_SSM_KEY = "/idp-v2/chat/models"
+_MODEL_ALLOWLIST_TTL_SECONDS = 300
+# Built-in catalog of the shipped models: model id -> supportsReasoning. Mirrors
+# the backend's default catalog (packages/backend/app/routers/chat.py). Used
+# ONLY when the SSM catalog is missing/malformed/empty, so the default selector
+# works before the operator creates the parameter. A valid SSM catalog REPLACES
+# it (matching the backend), so removing a model from SSM actually disallows it.
+# We keep supportsReasoning (not just ids) so effort is gated on the RESOLVED
+# model's capability, not on the originally-requested one (which may have been
+# dropped and fallen back to a model that rejects effort).
+_DEFAULT_MODEL_CATALOG: dict[str, bool] = {
+    "global.anthropic.claude-sonnet-5": True,
+    "global.anthropic.claude-opus-4-8": True,
+    "global.anthropic.claude-sonnet-4-6": False,
+}
+# (catalog dict, fetched_at monotonic) - refreshed lazily past the TTL.
+_model_catalog_cache: tuple[dict[str, bool], float] | None = None
+
+
+class _ModelMetrics(BaseModel):
+    intelligence: int
+    speed: int
+    context: int
+    cost: int
+
+
+class _ModelCatalogEntry(BaseModel):
+    """Mirror of the backend's ModelCatalogEntry (chat.py). The agent validates
+    the SSM catalog with the SAME full-field schema as the backend, so both
+    agree on which entries are valid - a partial entry like {"value": "x"} is
+    rejected by both, not accepted by one and shown-as-invalid by the other."""
+
+    value: str
+    label: str
+    description: str
+    contextWindow: str
+    inputPrice: str
+    outputPrice: str
+    metrics: _ModelMetrics
+    supportsReasoning: bool = True
+
+
+def _model_catalog() -> dict[str, bool]:
+    """Return the model catalog (id -> supportsReasoning) from SSM (cached).
+
+    A valid, non-empty SSM catalog (validated with the full backend schema) is
+    authoritative and REPLACES the built-in defaults, so a model removed from
+    SSM is no longer callable and a partial/invalid entry can't sneak a model
+    in. The built-in defaults are used only when SSM is missing/malformed/empty.
+    """
+    global _model_catalog_cache
+    now = time.monotonic()
+    if _model_catalog_cache is not None and now - _model_catalog_cache[1] < _MODEL_ALLOWLIST_TTL_SECONDS:
+        return _model_catalog_cache[0]
+
+    config = get_config()
+    result = _DEFAULT_MODEL_CATALOG
+    try:
+        ssm = boto3.client("ssm", region_name=config.aws_region)
+        raw = ssm.get_parameter(Name=MODEL_CATALOG_SSM_KEY)["Parameter"]["Value"]
+        parsed = json.loads(raw)
+        # Validate every entry with the full schema; any invalid entry raises
+        # and we keep the built-in defaults (same contract as the backend).
+        entries = [_ModelCatalogEntry.model_validate(item) for item in parsed]
+        catalog = {e.value: e.supportsReasoning for e in entries}
+        if catalog:
+            result = catalog
+    except (BotoCoreError, ClientError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        # Parameter missing/malformed - keep the built-in defaults.
+        result = _DEFAULT_MODEL_CATALOG
+
+    _model_catalog_cache = (result, now)
+    return result
+
+
+def _resolve_model(requested: str | None, default: str) -> tuple[str, bool]:
+    """Validate a client-requested model_id against the catalog.
+
+    Returns (resolved_model_id, supports_reasoning). The requested id is used
+    ONLY if it is in the authoritative catalog - the config default is NOT
+    auto-trusted (a request equal to the default is still checked), so removing
+    the default from SSM disallows it too. When neither the request nor the
+    default is allowed, we fall back to a deterministic (sorted-first) allowed
+    id so the agent still runs; if the catalog is somehow empty we use the
+    config default as the last-resort baseline. supports_reasoning is read for
+    the RESOLVED model, so effort is never sent to a model that rejects it.
+    """
+    catalog = _model_catalog()
+    if requested and requested in catalog:
+        return requested, catalog[requested]
+    if default in catalog:
+        return default, catalog[default]
+    if catalog:
+        chosen = next(iter(sorted(catalog)))
+        return chosen, catalog[chosen]
+    # Empty catalog (shouldn't happen): last-resort baseline, assume reasoning
+    # is supported (the shipped default models do).
+    return default, True
+
+
+# UI reasoning level -> Bedrock effort. Both Opus 4.8 and Sonnet 5 accept effort
+# via additional_request_fields as {"output_config": {"effort": ...}}. The UI's
+# "high" maps to "xhigh" - Anthropic recommends xhigh for agentic use cases,
+# which is what this agent does.
+REASONING_TO_EFFORT = {
+    "low": "low",
+    "medium": "medium",
+    "high": "xhigh",
+}
+
+
 @contextmanager
 def get_agent(
     session_id: str,
     project_id: str | None = None,
     user_id: str | None = None,
     agent_id: str | None = None,
+    model_id: str | None = None,
+    reasoning: str | None = None,
 ):
     """Get an agent instance with S3-based session management.
 
@@ -71,6 +193,8 @@ def get_agent(
         project_id: Project ID for document search (optional for init)
         user_id: User ID for session isolation (optional)
         agent_id: Custom agent ID for prompt injection (optional)
+        model_id: Bedrock model id to run this turn (falls back to config default)
+        reasoning: UI reasoning level (low/medium/high) -> output_config.effort
 
     Yields:
         Agent instance with session management configured
@@ -96,6 +220,8 @@ def get_agent(
         use_llm,
         interpreter.code_interpreter,
         create_artifact_path_tool(user_id, project_id),
+        render_chart,
+        ask_user,
     ]
 
     config = get_config()
@@ -112,11 +238,23 @@ def get_agent(
         language_code=language_code,
     )
 
-    bedrock_model = BedrockModel(
-        model_id=config.bedrock_model_id,
-        region_name=config.aws_region,
-        boto_client_config=BotocoreConfig(read_timeout=600),
-    )
+    # Validate the requested model_id against the SSM catalog; an unknown id
+    # (e.g. a tampered request, or a model removed from the catalog) falls back
+    # to an allowed model. supports_reasoning is for the RESOLVED model.
+    resolved_model_id, supports_reasoning = _resolve_model(model_id, config.bedrock_model_id)
+    # Attach output_config.effort only when the client sent a reasoning level
+    # AND the resolved model actually supports effort. Gating on the resolved
+    # model (not the request) means a fallback to a no-effort model like Sonnet
+    # 4.6 won't send an effort field that Bedrock would reject.
+    model_kwargs = {
+        "model_id": resolved_model_id,
+        "region_name": config.aws_region,
+        "boto_client_config": BotocoreConfig(read_timeout=600),
+    }
+    if supports_reasoning and reasoning in REASONING_TO_EFFORT:
+        effort = REASONING_TO_EFFORT[reasoning]
+        model_kwargs["additional_request_fields"] = {"output_config": {"effort": effort}}
+    bedrock_model = BedrockModel(**model_kwargs)
 
     hooks: list[HookProvider] = [
         ToolParameterEnforcerHook(user_id=user_id, project_id=project_id),

--- a/packages/agents/idp-agent/main.py
+++ b/packages/agents/idp-agent/main.py
@@ -105,6 +105,8 @@ async def invoke(request: dict):
         project_id=req.project_id,
         user_id=req.user_id,
         agent_id=req.agent_id,
+        model_id=req.model_id,
+        reasoning=req.reasoning,
     ) as agent:
         content = [block.to_strands() for block in req.prompt]
         stream = agent.stream_async(content)

--- a/packages/agents/idp-agent/models.py
+++ b/packages/agents/idp-agent/models.py
@@ -74,3 +74,7 @@ class InvokeRequest(BaseModel):
     project_id: str
     user_id: str | None = None
     agent_id: str | None = None
+    # Optional per-turn model override. model_id is passed straight to Bedrock
+    # (the runtime IAM role gates access); reasoning maps to output_config.effort.
+    model_id: str | None = None
+    reasoning: str | None = None

--- a/packages/agents/idp-agent/prompts.py
+++ b/packages/agents/idp-agent/prompts.py
@@ -101,8 +101,29 @@ When a question needs BOTH (e.g. "the gaming OLED TV — tell me its price and s
 - For comparisons or tabular data, use markdown tables.
 - Keep responses focused and relevant. Avoid unnecessary preamble.
 
+### Visualizing numbers (render_chart)
+- When an answer centers on numeric data you just fetched — a metric per item,
+  item-vs-item comparison, or a value over time — call `render_chart` to show it
+  inline as a chart card, in addition to a short prose summary.
+- Chart types: "hbar" (a quantity per label), "compare" (side-by-side bars
+  across named items per label), "timeline" (a value over dated points),
+  "donut" (composition / share of a whole), "stacked" (vertical bars split into
+  named segments, part-to-whole across categories), "scatter" (correlation
+  between two numeric variables). Pick the shape that fits the question.
+- Every `value` MUST come from a previous tool result in the same turn. Never
+  invent numbers to fill a chart. If you have no real numbers, don't chart.
+- Keep the prose answer too; the chart complements it, not replaces it.
+
+### Asking the user to choose (ask_user)
+- When a decision is the user's to make and you must not guess (ambiguous
+  choice, missing required parameter, confirmation before an expensive or
+  irreversible action), call `ask_user` with structured options instead of
+  guessing or writing "reply with A or B" in prose.
+- The user's selection arrives as their next message; read it and act on it.
+
 ### Handling Ambiguity
 - If the user's question is ambiguous, ask a clarifying question before searching.
+  Prefer `ask_user` with concrete options when the ambiguity is a discrete choice.
 - If multiple interpretations are possible, address the most likely one and mention alternatives.
 
 ### Multi-turn Conversations

--- a/packages/agents/idp-agent/tools/ask.py
+++ b/packages/agents/idp-agent/tools/ask.py
@@ -1,0 +1,86 @@
+"""ask_user tool - renders an inline question card in the chat so the user
+answers a structured single/multi/free-text prompt in place. The answer is
+sent back as the user's next message, so the agent picks up the choice on the
+following turn."""
+
+import json
+from typing import Any
+
+from strands import tool
+
+
+@tool
+def ask_user(questions: list[dict[str, Any]] | None = None) -> str:
+    """Ask the user one or more structured questions, rendered as an inline
+    question card in the chat.
+
+    Use this when a decision is the user's to make and you must not guess -
+    e.g. an ambiguous choice between options, a missing parameter, or a
+    confirmation before an expensive/irreversible action. Prefer this over
+    guessing and over a wall of prose asking the user to "reply with A or B".
+
+    Args:
+      questions: list of question objects. Each:
+        {
+          "kind": "single" | "multi" | "text",
+          "title": str,                # the question, natural language
+          "description": str?,         # optional helper line
+          "options": [                 # omit for kind="text"
+            {"id": str, "label": str, "description": str?}
+          ],
+          "allow_custom": bool?,       # show a free-text "other" row
+        }
+        For a yes/no question use kind="single" with two options.
+
+    Returns: a JSON envelope the chat renders as a question card. The user's
+    selection is posted back as their next message, so read it on the next turn
+    and act on it.
+    """
+    if not isinstance(questions, list) or not questions:
+        return json.dumps(
+            {"_ui_action": "error", "error": "questions must be a non-empty list"},
+            ensure_ascii=False,
+        )
+
+    norm: list[dict[str, Any]] = []
+    for q in questions:
+        if not isinstance(q, dict):
+            continue
+        kind = q.get("kind") or "single"
+        if kind not in ("single", "multi", "text"):
+            kind = "single"
+        title = str(q.get("title") or "").strip()
+        if not title:
+            continue
+        entry: dict[str, Any] = {"kind": kind, "title": title}
+        if q.get("description"):
+            entry["description"] = str(q["description"])
+        opts = q.get("options")
+        if isinstance(opts, list) and kind != "text":
+            entry["options"] = [
+                {
+                    "id": str(o.get("id")),
+                    "label": str(o.get("label") or o.get("id")),
+                    **(
+                        {"description": str(o["description"])}
+                        if isinstance(o, dict) and o.get("description")
+                        else {}
+                    ),
+                }
+                for o in opts
+                if isinstance(o, dict) and o.get("id")
+            ]
+        if q.get("allow_custom"):
+            entry["allowCustom"] = True
+        norm.append(entry)
+
+    if not norm:
+        return json.dumps(
+            {"_ui_action": "error", "error": "no valid questions"},
+            ensure_ascii=False,
+        )
+
+    return json.dumps(
+        {"_ui_action": "ask_user", "questions": norm},
+        ensure_ascii=False,
+    )

--- a/packages/agents/idp-agent/tools/charts.py
+++ b/packages/agents/idp-agent/tools/charts.py
@@ -1,0 +1,102 @@
+"""render_chart tool - emits a `_ui_action=render_chart` payload the frontend
+draws inline as a small SVG chart card (no charting library)."""
+
+import json
+from typing import Any
+
+from strands import tool
+
+
+@tool
+def render_chart(
+    chart_type: str,
+    title: str,
+    series: list[dict[str, Any]],
+    subtitle: str | None = None,
+    note: str | None = None,
+    unit: str | None = None,
+    x_label: str | None = None,
+    y_label: str | None = None,
+) -> str:
+    """Render an inline chart card inside the chat reply.
+
+    Use this to visualise numeric data the user asks about - a comparison of
+    metrics, a composition/share, item-vs-item values, a value over time, or a
+    correlation between two variables. The chat panel renders the spec as a
+    small SVG card next to the assistant message, so the user sees the answer
+    AND the chart at a glance instead of a wall of numbers.
+
+    Always pair this with the data-fetching tool that produced the numbers.
+    Do NOT hallucinate values into the series - every `value` must come from a
+    previous tool result (search, SQL, etc.) in the same turn. Also keep the
+    prose summary: the returned JSON contains the numbers so the answer still
+    reads if the chart can't render.
+
+    Args:
+      chart_type: pick the shape that fits the question:
+        - "hbar": horizontal bars, a quantity per label (optionally vs a
+          max/target). Ranking or per-item magnitude.
+        - "compare": side-by-side bars across N named items per label (A vs B
+          per category).
+        - "timeline": a value over dated points (recurrence/trend with day-gap
+          connectors).
+        - "donut": composition / share of a whole. Best for "what fraction is
+          each category" (e.g. class distribution, gender split). Shows total
+          in the center and percentages per slice.
+        - "stacked": vertical stacked bars - each label's bar is split into
+          named segments. Best for part-to-whole comparison across categories
+          (e.g. survived vs died stacked per class).
+        - "scatter": points on an X/Y plane. Best for the correlation between
+          two numeric variables (e.g. fare vs age).
+      title: Headline shown in the chart card (natural language).
+      series: Rows to plot. Schema depends on chart_type:
+        hbar: {"label": str, "value": number, "max": number?, "unit": str?,
+               "tone": "ok"|"warn"|"danger"?}
+        compare: {"label": str, "unit": str?,
+                  "values": [{"name": str, "value": number, "tone": ...?}]}
+        timeline: {"date": "YYYY-MM-DD", "value": number|null, "tag": str?,
+                   "tone": ...?}  (date MUST be ISO; null value = upcoming)
+        donut: {"label": str, "value": number, "tone": ...?}  (one slice each)
+        stacked: {"label": str, "unit": str?,
+                  "segments": [{"name": str, "value": number, "tone": ...?}]}
+        scatter: {"x": number, "y": number, "label": str?, "tone": ...?}
+      unit: value-column unit for "timeline"/"donut" (e.g. persons); ignored by
+        the others (their units are per-row).
+      x_label: axis label for "scatter" X (the horizontal variable).
+      y_label: axis label for "scatter" Y (the vertical variable).
+      subtitle: Optional smaller text under the title.
+      note: Optional footer caption (e.g. the basis/assumption of the numbers).
+
+    Returns: a JSON envelope the frontend turns into a chat-side chart card.
+    """
+    valid_types = {"hbar", "compare", "timeline", "donut", "stacked", "scatter"}
+    if chart_type not in valid_types:
+        return json.dumps(
+            {
+                "_ui_action": "error",
+                "error": f"unknown chart_type: {chart_type!r}. valid: {sorted(valid_types)}",
+            },
+            ensure_ascii=False,
+        )
+    if not isinstance(series, list) or not series:
+        return json.dumps(
+            {"_ui_action": "error", "error": "series must be a non-empty list"},
+            ensure_ascii=False,
+        )
+    chart: dict[str, Any] = {
+        "type": chart_type,
+        "title": title,
+        "series": series,
+    }
+    if subtitle:
+        chart["subtitle"] = subtitle
+    if note:
+        chart["note"] = note
+    if unit and chart_type in ("timeline", "donut"):
+        chart["unit"] = unit
+    if chart_type == "scatter":
+        if x_label:
+            chart["xLabel"] = x_label
+        if y_label:
+            chart["yLabel"] = y_label
+    return json.dumps({"_ui_action": "render_chart", "chart": chart}, ensure_ascii=False)

--- a/packages/backend/app/routers/chat.py
+++ b/packages/backend/app/routers/chat.py
@@ -1,6 +1,9 @@
 import json
+import time
 from datetime import datetime
 
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 from fastapi import APIRouter, Header, HTTPException, Query
 from pydantic import BaseModel
 
@@ -11,6 +14,111 @@ from app.message import ContentItem, parse_content_items
 from app.s3 import delete_s3_prefix, get_s3_client
 
 router = APIRouter(prefix="/chat", tags=["chat"])
+
+# SSM parameter holding the chat model catalog JSON. Operators edit this to
+# add/remove models without redeploying; the agent passes model_id straight to
+# Bedrock so no infra change is needed for a new Anthropic model.
+MODEL_CATALOG_SSM_KEY = "/idp-v2/chat/models"
+_MODEL_CATALOG_TTL_SECONDS = 60
+
+# Built-in fallback used when the SSM parameter is absent or unreadable.
+_DEFAULT_MODEL_CATALOG: list[dict] = [
+    {
+        "value": "global.anthropic.claude-sonnet-5",
+        "label": "Sonnet 5",
+        "description": "일상 작업에 최적",
+        "contextWindow": "1M tokens",
+        "inputPrice": "$3.00 / 1M",
+        "outputPrice": "$15.00 / 1M",
+        "metrics": {"intelligence": 8, "speed": 8, "context": 10, "cost": 7},
+    },
+    {
+        "value": "global.anthropic.claude-opus-4-8",
+        "label": "Opus 4.8",
+        "description": "복잡한 작업에 가장 강력",
+        "contextWindow": "1M tokens",
+        "inputPrice": "$5.00 / 1M",
+        "outputPrice": "$25.00 / 1M",
+        "metrics": {"intelligence": 10, "speed": 5, "context": 10, "cost": 5},
+    },
+    {
+        "value": "global.anthropic.claude-sonnet-4-6",
+        "label": "Sonnet 4.6",
+        "description": "안정적인 이전 세대 모델",
+        "contextWindow": "200K tokens",
+        "inputPrice": "$3.00 / 1M",
+        "outputPrice": "$15.00 / 1M",
+        "metrics": {"intelligence": 7, "speed": 8, "context": 8, "cost": 7},
+        # Sonnet 4.6 has no effort/reasoning control.
+        "supportsReasoning": False,
+    },
+]
+
+# (models, fetched_at monotonic) - refreshed lazily once the TTL elapses.
+_model_catalog_cache: tuple[list["ModelCatalogEntry"], float] | None = None
+
+
+class ModelMetrics(BaseModel):
+    intelligence: int
+    speed: int
+    context: int
+    cost: int
+
+
+class ModelCatalogEntry(BaseModel):
+    """One selectable chat model. Every field the frontend selector renders is
+    required (metrics especially), so a malformed SSM entry is rejected rather
+    than crashing the UI."""
+
+    value: str
+    label: str
+    description: str
+    contextWindow: str
+    inputPrice: str
+    outputPrice: str
+    metrics: ModelMetrics
+    supportsReasoning: bool = True
+
+
+class ModelCatalogResponse(BaseModel):
+    models: list[ModelCatalogEntry]
+
+
+# Built-in fallback, validated once at import so a typo here fails fast in tests.
+_DEFAULT_CATALOG_MODELS: list[ModelCatalogEntry] = [ModelCatalogEntry(**m) for m in _DEFAULT_MODEL_CATALOG]
+
+
+def _load_model_catalog() -> list[ModelCatalogEntry]:
+    """Read + validate the model catalog from SSM (cached), falling back to the
+    built-in default on any read/parse/validation failure so a bad SSM value
+    can never break the selector."""
+    global _model_catalog_cache
+    now = time.monotonic()
+    if _model_catalog_cache is not None and now - _model_catalog_cache[1] < _MODEL_CATALOG_TTL_SECONDS:
+        return _model_catalog_cache[0]
+
+    config = get_config()
+    models = _DEFAULT_CATALOG_MODELS
+    try:
+        ssm = boto3.client("ssm", region_name=config.aws_region)
+        raw = ssm.get_parameter(Name=MODEL_CATALOG_SSM_KEY)["Parameter"]["Value"]
+        parsed = json.loads(raw)
+        # Validate every entry; an invalid or empty catalog raises and we keep
+        # the default.
+        validated = [ModelCatalogEntry.model_validate(item) for item in parsed]
+        if validated:
+            models = validated
+    except (BotoCoreError, ClientError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        models = _DEFAULT_CATALOG_MODELS
+
+    _model_catalog_cache = (models, now)
+    return models
+
+
+@router.get("/models")
+async def get_model_catalog() -> ModelCatalogResponse:
+    """Return the selectable chat model catalog (SSM-backed, cached)."""
+    return ModelCatalogResponse(models=_load_model_catalog())
 
 
 class ChatMessage(BaseModel):

--- a/packages/backend/app/routers/documents.py
+++ b/packages/backend/app/routers/documents.py
@@ -1,7 +1,7 @@
 import contextlib
 import uuid
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.config import get_config
@@ -127,9 +127,28 @@ class DocumentProgress(BaseModel):
     steps: dict[str, StepProgress]
 
 
+# Non-terminal workflow states that should be returned when active_only=true.
+# A completed/failed/needs_user_fix document is terminal and, once cleared from
+# the UI, must not be re-surfaced by a routine progress poll triggered by an
+# unrelated new upload.
+_ACTIVE_WF_STATUSES = frozenset({"pending", "in_progress", "processing", "reanalyzing"})
+
+
 @router.get("/progress")
-def get_documents_progress(project_id: str) -> list[DocumentProgress]:
-    """Get workflow step progress for all documents (including completed)."""
+def get_documents_progress(
+    project_id: str,
+    active_only: bool = Query(
+        default=False,
+        description="When true, return only documents with a non-terminal (in-progress) workflow.",
+    ),
+) -> list[DocumentProgress]:
+    """Get workflow step progress for documents.
+
+    By default returns all documents (including terminal ones) for a full
+    reconcile. With active_only=true, returns only in-progress/reanalyzing
+    workflows - used by routine polling so a new upload's progress fetch does
+    not re-surface unrelated terminal documents.
+    """
     documents = query_documents(project_id)
     active_docs = [doc for doc in documents if doc.data.status != "deleted"]
 
@@ -143,6 +162,8 @@ def get_documents_progress(project_id: str) -> list[DocumentProgress]:
         if workflows:
             wf = workflows[0]
             wf_id = wf.SK.replace("WF#", "")
+            if active_only and wf.data.status not in _ACTIVE_WF_STATUSES:
+                continue
             doc_workflow_map[wf_id] = (doc.data.document_id, wf.data.status)
 
     if not doc_workflow_map:

--- a/packages/common/constructs/src/app/agents/idp-agent.ts
+++ b/packages/common/constructs/src/app/agents/idp-agent.ts
@@ -1,6 +1,8 @@
 import { Construct } from 'constructs';
+import { ArnFormat, Stack } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import { SSM_KEYS } from '../../constants/ssm-keys.js';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 import { IQueue } from 'aws-cdk-lib/aws-sqs';
@@ -133,6 +135,22 @@ export class IdpAgent extends Construct {
           'bedrock:Rerank',
         ],
         resources: ['*'],
+      }),
+    );
+
+    // Read the operator-managed chat model catalog to validate a requested
+    // model_id against the allowlist (defense beyond the broad InvokeModel grant).
+    this.runtime.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['ssm:GetParameter'],
+        resources: [
+          Stack.of(this).formatArn({
+            service: 'ssm',
+            resource: 'parameter',
+            resourceName: SSM_KEYS.CHAT_MODEL_CATALOG.replace(/^\//, ''),
+            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+          }),
+        ],
       }),
     );
 

--- a/packages/common/constructs/src/app/apis/backend.ts
+++ b/packages/common/constructs/src/app/apis/backend.ts
@@ -197,6 +197,23 @@ export class Backend extends Construct {
       }),
     );
 
+    // Grant read on the operator-managed chat model catalog parameter (GET
+    // /chat/models). The parameter is not created by CDK - operators edit it to
+    // add/remove models without a redeploy.
+    taskRole.addToPrincipalPolicy(
+      new PolicyStatement({
+        actions: ['ssm:GetParameter'],
+        resources: [
+          Stack.of(this).formatArn({
+            service: 'ssm',
+            resource: 'parameter',
+            resourceName: SSM_KEYS.CHAT_MODEL_CATALOG.replace(/^\//, ''),
+            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+          }),
+        ],
+      }),
+    );
+
     // Grant Step Functions start execution permission for re-analysis
     taskRole.addToPrincipalPolicy(
       new PolicyStatement({

--- a/packages/common/constructs/src/constants/ssm-keys.ts
+++ b/packages/common/constructs/src/constants/ssm-keys.ts
@@ -43,4 +43,7 @@ export const SSM_KEYS = {
   // Lance Service
   TOKA_FUNCTION_NAME: '/idp-v2/lance-service/toka/function-name',
   LANCE_SERVICE_FUNCTION_ARN: '/idp-v2/lance-service/function-arn',
+  // Chat model catalog (operator-managed, not created by CDK). Edit this
+  // parameter to add/remove selectable chat models without redeploying.
+  CHAT_MODEL_CATALOG: '/idp-v2/chat/models',
 } as const;

--- a/packages/frontend/src/components/ChatPanel/ChatInputBox.tsx
+++ b/packages/frontend/src/components/ChatPanel/ChatInputBox.tsx
@@ -14,6 +14,8 @@ import {
 import { formatFileSize, getFileTypeInfo } from './utils';
 import { useRuntimeConfig } from '../../hooks/useRuntimeConfig';
 import ToolsMenuPopover from './ToolsMenuPopover';
+import { ModelSelectorPrompt } from './ModelSelectorPrompt';
+import type { LlmModel, ReasoningLevel } from './ModelSelectorPrompt';
 import type {
   AttachedFile,
   Artifact,
@@ -48,6 +50,11 @@ interface ChatInputBoxProps {
   onInputChange: (value: string) => void;
   onSendMessage: (files: AttachedFile[], message?: string) => void;
   onStop?: () => void;
+  models?: readonly LlmModel[];
+  modelId?: string;
+  reasonings?: Record<string, ReasoningLevel>;
+  onModelChange?: (modelValue: string) => void;
+  onReasoningChange?: (reasonings: Record<string, ReasoningLevel>) => void;
   onAgentSelect?: (agentName: string | null) => void;
   onAgentClick: () => void;
   voiceChat: InputBoxVoiceChat;
@@ -70,6 +77,11 @@ export default function ChatInputBox({
   onInputChange,
   onSendMessage,
   onStop,
+  models,
+  modelId,
+  reasonings,
+  onModelChange,
+  onReasoningChange,
   onAgentSelect,
   onAgentClick,
   voiceChat,
@@ -660,6 +672,23 @@ export default function ChatInputBox({
                   )}
                 </div>
               )}
+
+              {/* Model selector (text chat only; voice chat picks its own model) */}
+              {!voiceChat.mode &&
+                models &&
+                models.length > 0 &&
+                modelId &&
+                onModelChange && (
+                  <ModelSelectorPrompt
+                    models={models}
+                    value={modelId}
+                    reasonings={reasonings ?? {}}
+                    onModelChange={(model) => onModelChange(model.value)}
+                    onReasoningChange={(_modelValue, _reasoning, next) =>
+                      onReasoningChange?.(next)
+                    }
+                  />
+                )}
 
               {/* Selected tool chips */}
               {(selectedAgent || voiceChat.mode) && (

--- a/packages/frontend/src/components/ChatPanel/MessageList.tsx
+++ b/packages/frontend/src/components/ChatPanel/MessageList.tsx
@@ -37,6 +37,8 @@ interface MessageListProps {
   onGraphView?: (data: GraphSearchResult) => void;
   documents: Document[];
   chatEndRef: React.RefObject<HTMLDivElement | null>;
+  /** Post an ask_user answer back as the user's next message. */
+  onAnswer?: (content: string) => void;
 }
 
 export default function MessageList({
@@ -56,6 +58,7 @@ export default function MessageList({
   onGraphView,
   documents,
   chatEndRef,
+  onAnswer,
 }: MessageListProps) {
   const { t } = useTranslation();
 
@@ -98,6 +101,8 @@ export default function MessageList({
             onViewDetails={onViewDetails}
             onGraphView={onGraphView}
             documents={documents}
+            onAnswer={onAnswer}
+            answered={message.id.startsWith('history-')}
           />
         ) : message.isStageResult ? (
           <StageResult key={message.id} message={message} />
@@ -187,6 +192,7 @@ export default function MessageList({
                     onViewDetails={onViewDetails}
                     onGraphView={onGraphView}
                     documents={documents}
+                    onAnswer={onAnswer}
                   />
                 );
               }

--- a/packages/frontend/src/components/ChatPanel/ModelSelectorPrompt.tsx
+++ b/packages/frontend/src/components/ChatPanel/ModelSelectorPrompt.tsx
@@ -1,0 +1,487 @@
+import { Combobox } from '@base-ui/react/combobox';
+import { PreviewCard } from '@base-ui/react/preview-card';
+import { Brain, ChevronDown, Search } from 'lucide-react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '../../lib/utils';
+
+// Chat model with the metric bars shown in the preview card. Only Anthropic
+// models are offered here (the agent passes model_id straight to Bedrock and
+// the runtime IAM role gates access), so there is no provider column - reasoning
+// is the only per-model knob.
+export type LlmModel = {
+  value: string;
+  label: string;
+  description: string;
+  contextWindow: string;
+  inputPrice: string;
+  outputPrice: string;
+  metrics: {
+    intelligence: number;
+    speed: number;
+    context: number;
+    cost: number;
+  };
+  // Whether the model accepts a reasoning/effort level. Models without it
+  // (e.g. Sonnet 4.6) hide the reasoning control and never send a reasoning
+  // value. Defaults to true when omitted.
+  supportsReasoning?: boolean;
+};
+
+export type ReasoningLevel = 'low' | 'medium' | 'high';
+
+export type ModelSelectorPromptProps = {
+  models: readonly LlmModel[];
+  value: string;
+  reasonings: Record<string, ReasoningLevel>;
+  onModelChange: (model: LlmModel) => void;
+  onReasoningChange: (
+    modelValue: string,
+    reasoning: ReasoningLevel,
+    reasonings: Record<string, ReasoningLevel>,
+  ) => void;
+};
+
+const DEFAULT_REASONING: ReasoningLevel = 'medium';
+
+function getReasoning(
+  reasonings: Record<string, ReasoningLevel>,
+  modelValue: string,
+): ReasoningLevel {
+  return reasonings[modelValue] ?? DEFAULT_REASONING;
+}
+
+const REASONING_INTELLIGENCE_DELTA: Record<ReasoningLevel, number> = {
+  low: -2,
+  medium: 0,
+  high: 2,
+};
+
+function clampMetric(value: number) {
+  return Math.min(10, Math.max(1, Math.round(value)));
+}
+
+// Only surface a badge when reasoning is off the default, so the trigger stays
+// clean for the common case.
+function ReasoningBadge({ reasoning }: { reasoning: ReasoningLevel }) {
+  const { t } = useTranslation();
+  if (reasoning === 'medium') return null;
+  return (
+    <span className="inline-flex shrink-0 items-center gap-0.5 rounded bg-slate-100 dark:bg-white/10 px-1 py-0.5 text-[10px] text-slate-500 dark:text-slate-400">
+      <Brain className="w-2.5 h-2.5 text-blue-500" />
+      {t(`chat.model.${reasoning}`)}
+    </span>
+  );
+}
+
+// Metric bar color by score (invert flips it so low cost reads green).
+function metricColor(value: number, invert: boolean) {
+  const score = invert ? 11 - value : value;
+  if (score >= 8) return '#10b981'; // emerald-500
+  if (score >= 6) return '#3b82f6'; // blue-500
+  if (score >= 4) return '#f59e0b'; // amber-500
+  return '#ef4444'; // red-500
+}
+
+// A single segment that grows up from the bottom on mount, so bars animate in
+// on model swap / reasoning change.
+function GrowSegment({ color, delay }: { color: string; delay: number }) {
+  const [grown, setGrown] = useState(false);
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setGrown(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+  return (
+    <div
+      className="h-full w-full origin-bottom rounded-sm transition-transform duration-300 ease-out"
+      style={{
+        backgroundColor: color,
+        transform: grown ? 'scaleY(1)' : 'scaleY(0)',
+        transitionDelay: `${delay}ms`,
+      }}
+    />
+  );
+}
+
+function MetricBar({
+  label,
+  value,
+  info,
+  invert = false,
+  animationKey,
+}: {
+  label: string;
+  value: number;
+  info?: string;
+  invert?: boolean;
+  animationKey: string;
+}) {
+  const color = metricColor(value, invert);
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between gap-1">
+        <span className="font-mono text-[10px] font-medium uppercase leading-none text-slate-400 dark:text-slate-500">
+          {label}
+        </span>
+        {info ? (
+          <span
+            className="cursor-help text-[10px] leading-none text-slate-400 dark:text-slate-500"
+            title={info}
+          >
+            &#9432;
+          </span>
+        ) : null}
+      </div>
+      <div
+        aria-label={`${label}: ${value} out of 10`}
+        className="grid grid-cols-10 gap-1"
+        key={animationKey}
+        role="img"
+      >
+        {Array.from({ length: 10 }, (_, index) => (
+          <div
+            className="h-3 overflow-hidden rounded-sm bg-slate-100 dark:bg-white/10"
+            key={index}
+          >
+            {index < value ? (
+              <GrowSegment color={color} delay={index * 25} />
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SegmentedRadio<TValue extends string>({
+  ariaLabel,
+  onValueChange,
+  options,
+  value,
+}: {
+  ariaLabel: string;
+  onValueChange: (value: TValue) => void;
+  options: { label: string; value: TValue }[];
+  value: TValue;
+}) {
+  return (
+    <div aria-label={ariaLabel} className="flex gap-1" role="radiogroup">
+      {options.map((option) => {
+        const checked = option.value === value;
+        return (
+          <button
+            aria-checked={checked}
+            className={cn(
+              'flex-1 rounded-lg px-2 py-1 text-xs transition-colors',
+              checked
+                ? 'bg-blue-500 text-white'
+                : 'bg-slate-100 dark:bg-white/10 text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-white/15 hover:text-slate-700 dark:hover:text-slate-200',
+            )}
+            key={option.value}
+            onClick={() => onValueChange(option.value)}
+            role="radio"
+            type="button"
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ModelPreviewPanel({
+  model,
+  reasoning,
+  onReasoningChange,
+}: {
+  model: LlmModel;
+  reasoning: ReasoningLevel;
+  onReasoningChange: (reasoning: ReasoningLevel) => void;
+}) {
+  const { t } = useTranslation();
+  const adjustedMetrics = useMemo(
+    () => ({
+      intelligence: clampMetric(
+        model.metrics.intelligence + REASONING_INTELLIGENCE_DELTA[reasoning],
+      ),
+      speed: model.metrics.speed,
+      context: model.metrics.context,
+      cost: model.metrics.cost,
+    }),
+    [model.metrics, reasoning],
+  );
+  return (
+    <div className="flex w-56 flex-col divide-y divide-slate-200 dark:divide-slate-700">
+      <div className="flex flex-col gap-3 p-3">
+        <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+          {model.label}
+        </p>
+        <p className="text-pretty text-xs leading-4 text-slate-500 dark:text-slate-400">
+          {model.description}
+        </p>
+        <div className="mt-2 grid grid-cols-2 gap-4 text-xs">
+          <MetricBar
+            animationKey={`${model.value}-${reasoning}`}
+            label={t('chat.model.intelligence', 'Intelligence')}
+            value={adjustedMetrics.intelligence}
+          />
+          <MetricBar
+            animationKey={model.value}
+            label={t('chat.model.speed', 'Speed')}
+            value={adjustedMetrics.speed}
+          />
+          <MetricBar
+            animationKey={model.value}
+            info={t('chat.model.contextWindow', {
+              value: model.contextWindow,
+              defaultValue: '{{value}} context window',
+            })}
+            label={t('chat.model.context', 'Context')}
+            value={adjustedMetrics.context}
+          />
+          <MetricBar
+            animationKey={model.value}
+            info={t('chat.model.priceInfo', {
+              input: model.inputPrice,
+              output: model.outputPrice,
+              defaultValue: '{{input}} input · {{output}} output',
+            })}
+            invert
+            label={t('chat.model.cost', 'Cost')}
+            value={adjustedMetrics.cost}
+          />
+        </div>
+      </div>
+      {model.supportsReasoning !== false ? (
+        <div className="flex flex-col gap-3 p-3">
+          <p className="font-mono text-[10px] font-semibold uppercase leading-none text-slate-500 dark:text-slate-400">
+            {t('chat.model.reasoning', 'Reasoning')}
+          </p>
+          <SegmentedRadio<ReasoningLevel>
+            ariaLabel={t('chat.model.reasoning', 'Reasoning')}
+            onValueChange={onReasoningChange}
+            options={[
+              { label: t('chat.model.low', 'Low'), value: 'low' },
+              { label: t('chat.model.medium', 'Medium'), value: 'medium' },
+              { label: t('chat.model.high', 'High'), value: 'high' },
+            ]}
+            value={reasoning}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ModelListWithScrollFade({
+  children,
+}: {
+  // Combobox.List renders items via a render function (item, index) => node.
+  children: ReactNode | ((item: LlmModel, index: number) => ReactNode);
+}) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const [showBottomFade, setShowBottomFade] = useState(false);
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    function updateBottomFade() {
+      const el = listRef.current;
+      if (!el) return;
+      const { scrollTop, scrollHeight, clientHeight } = el;
+      setShowBottomFade(scrollHeight - scrollTop - clientHeight > 4);
+    }
+    updateBottomFade();
+    list.addEventListener('scroll', updateBottomFade, { passive: true });
+    const resizeObserver = new ResizeObserver(updateBottomFade);
+    resizeObserver.observe(list);
+    return () => {
+      list.removeEventListener('scroll', updateBottomFade);
+      resizeObserver.disconnect();
+    };
+  }, []);
+  return (
+    <div className="relative">
+      <Combobox.List
+        className="max-h-64 overflow-y-auto overscroll-contain p-1"
+        ref={listRef}
+      >
+        {children}
+      </Combobox.List>
+      <div
+        aria-hidden="true"
+        className={cn(
+          'pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8 bg-gradient-to-t from-white dark:from-slate-800 to-transparent transition-opacity duration-150',
+          showBottomFade ? 'opacity-100' : 'opacity-0',
+        )}
+      />
+    </div>
+  );
+}
+
+function ModelComboboxItem({
+  model,
+  reasoning,
+  previewHandle,
+}: {
+  model: LlmModel;
+  reasoning: ReasoningLevel;
+  previewHandle: PreviewCard.Handle<LlmModel>;
+}) {
+  return (
+    <Combobox.Item
+      className="group w-full p-0 text-slate-500 dark:text-slate-400 data-[selected]:text-slate-800 dark:data-[selected]:text-slate-100"
+      value={model}
+    >
+      <PreviewCard.Trigger
+        className="flex w-full items-start gap-2 rounded-lg px-1.5 py-1.5 hover:bg-slate-100 dark:hover:bg-white/10 group-data-[selected]:bg-slate-100 dark:group-data-[selected]:bg-white/10"
+        closeDelay={180}
+        delay={80}
+        handle={previewHandle}
+        payload={model}
+        render={<div />}
+      >
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate">{model.label}</span>
+          <span className="truncate text-xs text-slate-500 dark:text-slate-400">
+            {model.description}
+          </span>
+        </div>
+        <ReasoningBadge reasoning={reasoning} />
+      </PreviewCard.Trigger>
+    </Combobox.Item>
+  );
+}
+
+/**
+ * Model picker with a hover preview card (metric bars + a per-model reasoning
+ * control). Reasoning is remembered per model. The trigger renders inline in
+ * the chat composer.
+ */
+export function ModelSelectorPrompt({
+  models,
+  value,
+  reasonings,
+  onModelChange,
+  onReasoningChange,
+}: ModelSelectorPromptProps) {
+  const { t } = useTranslation();
+  const fallbackModel = models[0];
+  const selectedModel = models.find((m) => m.value === value) ?? fallbackModel;
+  const previewHandle = useMemo(() => PreviewCard.createHandle<LlmModel>(), []);
+
+  function updateReasoning(modelValue: string, reasoning: ReasoningLevel) {
+    const next = { ...reasonings, [modelValue]: reasoning };
+    onReasoningChange(modelValue, reasoning, next);
+    // Changing a model's reasoning in its preview card also selects that model,
+    // so picking "Opus + High" applies immediately instead of only updating the
+    // reasoning of a model the user hasn't actually chosen.
+    if (modelValue !== selectedModel.value) {
+      const model = models.find((m) => m.value === modelValue);
+      if (model) onModelChange(model);
+    }
+  }
+  function closeModelPreview() {
+    previewHandle.close();
+  }
+
+  return (
+    <Combobox.Root<LlmModel>
+      autoHighlight
+      isItemEqualToValue={(item, nextValue) => item.value === nextValue.value}
+      items={models as LlmModel[]}
+      onInputValueChange={closeModelPreview}
+      onValueChange={(nextModel) => {
+        if (nextModel) onModelChange(nextModel);
+      }}
+      value={selectedModel}
+    >
+      <Combobox.Trigger
+        aria-label="Select model"
+        className="flex h-8 items-center gap-1 rounded-lg px-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 transition-colors hover:bg-slate-100 dark:hover:bg-white/10 hover:text-slate-700 dark:hover:text-slate-200 data-[popup-open]:bg-slate-100 dark:data-[popup-open]:bg-white/10"
+      >
+        <Combobox.Value>
+          {(model: LlmModel | null) =>
+            model ? (
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span className="truncate">{model.label}</span>
+                <ReasoningBadge
+                  reasoning={getReasoning(reasonings, model.value)}
+                />
+              </span>
+            ) : (
+              <span>{t('chat.model.select', 'Select model')}</span>
+            )
+          }
+        </Combobox.Value>
+        <Combobox.Icon className="text-slate-400 dark:text-slate-500">
+          <ChevronDown className="w-3.5 h-3.5" />
+        </Combobox.Icon>
+      </Combobox.Trigger>
+      <Combobox.Portal>
+        <Combobox.Positioner align="start" sideOffset={4}>
+          <Combobox.Popup
+            aria-label="Select model"
+            className="w-60 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg outline-none z-50"
+          >
+            <PreviewCard.Root<LlmModel> handle={previewHandle}>
+              {({ payload }) => (
+                <>
+                  <Combobox.InputGroup className="flex items-center gap-1.5 rounded-none border-0 border-b border-slate-200 dark:border-slate-700 bg-transparent px-2">
+                    <Combobox.Input
+                      className="w-full bg-transparent px-0 py-2 text-sm outline-none text-slate-800 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500"
+                      onFocus={closeModelPreview}
+                      placeholder={t(
+                        'chat.model.searchPlaceholder',
+                        'Search models...',
+                      )}
+                    />
+                    <Search
+                      aria-hidden="true"
+                      className="shrink-0 w-3.5 h-3.5 text-slate-400 dark:text-slate-500"
+                    />
+                  </Combobox.InputGroup>
+                  <Combobox.Empty>
+                    <div className="px-2 py-2 text-center text-xs font-medium text-slate-500 dark:text-slate-400">
+                      {t('chat.model.notFound', 'No models found')}
+                    </div>
+                  </Combobox.Empty>
+                  <ModelListWithScrollFade>
+                    {(model: LlmModel) => (
+                      <ModelComboboxItem
+                        key={model.value}
+                        model={model}
+                        previewHandle={previewHandle}
+                        reasoning={getReasoning(reasonings, model.value)}
+                      />
+                    )}
+                  </ModelListWithScrollFade>
+                  <PreviewCard.Portal keepMounted>
+                    <PreviewCard.Positioner
+                      align="center"
+                      className="z-[60]"
+                      side="right"
+                      sideOffset={8}
+                    >
+                      <PreviewCard.Popup className="overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg outline-none">
+                        {payload ? (
+                          <ModelPreviewPanel
+                            model={payload}
+                            onReasoningChange={(reasoning) =>
+                              updateReasoning(payload.value, reasoning)
+                            }
+                            reasoning={getReasoning(reasonings, payload.value)}
+                          />
+                        ) : null}
+                      </PreviewCard.Popup>
+                    </PreviewCard.Positioner>
+                  </PreviewCard.Portal>
+                </>
+              )}
+            </PreviewCard.Root>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
+  );
+}

--- a/packages/frontend/src/components/ChatPanel/QuestionCard.tsx
+++ b/packages/frontend/src/components/ChatPanel/QuestionCard.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '../../lib/utils';
+
+/**
+ * Inline question card for the chat - the agent (ask_user tool) asks a
+ * structured single/multi/free-text question and the user answers in place.
+ * On completion the answers are formatted and posted back as the user's next
+ * message so the agent reads the choice on its next turn. Adapted for the idp
+ * chat theme (slate, dark-mode aware).
+ */
+
+const QUESTION_CUSTOM_ID = '__custom__';
+
+function optionBadge(idx: number) {
+  return String.fromCharCode(65 + idx);
+}
+
+export type QuestionOption = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
+export type QuestionConfig = {
+  kind: 'single' | 'multi' | 'text';
+  title: string;
+  description?: string;
+  options?: QuestionOption[];
+  allowCustom?: boolean;
+  placeholder?: string;
+};
+
+export type QuestionAnswer = {
+  kind: 'single' | 'multi' | 'text' | 'skip';
+  selectedIds?: string[];
+  text?: string;
+};
+
+/** Parse an ask_user tool result into its question list. Returns null when the
+ *  payload isn't an ask card (so the caller falls back to the normal pill). */
+export function parseAskSpec(
+  resultText: string | undefined,
+): { questions: QuestionConfig[] } | null {
+  if (!resultText) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(resultText);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as { _ui_action?: string; questions?: unknown };
+  if (obj._ui_action !== 'ask_user') return null;
+  if (!Array.isArray(obj.questions) || obj.questions.length === 0) return null;
+  return { questions: obj.questions as QuestionConfig[] };
+}
+
+/** Turn the user's answers into a concise message the agent reads next turn
+ *  ("Q -> A" lines). */
+export function formatAnswersForAgent(
+  questions: QuestionConfig[],
+  answers: QuestionAnswer[],
+): string {
+  const lines = questions.map((q, i) => {
+    const a = answers[i];
+    if (!a || a.kind === 'skip') return `${q.title} -> (skipped)`;
+    if (a.kind === 'text') return `${q.title} -> ${a.text ?? ''}`;
+    const labels = (a.selectedIds ?? [])
+      .map((id) => q.options?.find((o) => o.id === id)?.label ?? id)
+      .filter(Boolean);
+    const parts = [...labels];
+    if (a.text) parts.push(a.text);
+    return `${q.title} -> ${parts.join(', ') || 'answered'}`;
+  });
+  return lines.join('\n');
+}
+
+function QuestionPrompt({
+  question,
+  questionIndex,
+  totalQuestions,
+  allowSkip = true,
+  onSubmit,
+}: {
+  question: QuestionConfig;
+  questionIndex: number;
+  totalQuestions: number;
+  allowSkip?: boolean;
+  onSubmit: (answer: QuestionAnswer) => void;
+}) {
+  const { t } = useTranslation();
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [customText, setCustomText] = useState('');
+  const [textValue, setTextValue] = useState('');
+  const customEnabled = question.allowCustom ?? false;
+  const isLast = questionIndex >= totalQuestions;
+
+  // Reset local state whenever the active question changes.
+  useEffect(() => {
+    setSelectedIds([]);
+    setCustomText('');
+    setTextValue('');
+  }, [question]);
+
+  const canSubmit = useMemo(() => {
+    if (question.kind === 'text') return textValue.trim().length > 0;
+    const selectedNonCustom = selectedIds.filter(
+      (id) => id !== QUESTION_CUSTOM_ID,
+    ).length;
+    const hasCustomText = customText.trim().length > 0;
+    const total = selectedNonCustom + (hasCustomText ? 1 : 0);
+    if (question.kind === 'single') return total === 1;
+    return total > 0;
+  }, [question.kind, selectedIds, customText, textValue]);
+
+  const toggleMulti = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  };
+
+  const handleCustomTextChange = (nextValue: string) => {
+    setCustomText(nextValue);
+    if (question.kind === 'single') {
+      setSelectedIds(nextValue.trim().length > 0 ? [QUESTION_CUSTOM_ID] : []);
+      return;
+    }
+    setSelectedIds((prev) => {
+      const hasCustom = prev.includes(QUESTION_CUSTOM_ID);
+      if (nextValue.trim().length > 0 && !hasCustom) {
+        return [...prev, QUESTION_CUSTOM_ID];
+      }
+      if (nextValue.trim().length === 0 && hasCustom) {
+        return prev.filter((id) => id !== QUESTION_CUSTOM_ID);
+      }
+      return prev;
+    });
+  };
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    if (question.kind === 'text') {
+      onSubmit({ kind: 'text', text: textValue.trim() });
+      return;
+    }
+    const selectedNonCustom = selectedIds.filter(
+      (id) => id !== QUESTION_CUSTOM_ID,
+    );
+    onSubmit({
+      kind: question.kind,
+      selectedIds: selectedNonCustom,
+      text: customText.trim() || undefined,
+    });
+  };
+
+  const options = question.options ?? [];
+  const optionRowBase =
+    'w-full text-left rounded-md px-2 py-1.5 flex items-center gap-2 transition-colors hover:bg-slate-100 dark:hover:bg-white/10';
+  const badgeBase =
+    'h-5 min-w-5 px-1 rounded-[4px] inline-flex items-center justify-center text-xs font-semibold border';
+  const badgeOff =
+    'bg-transparent text-slate-400 dark:text-slate-500 border-slate-200 dark:border-slate-600';
+  const badgeOn = 'bg-blue-500 text-white border-blue-500';
+
+  return (
+    <div className="space-y-2 px-3 py-2">
+      <div className="flex items-center gap-2 text-sm text-slate-800 dark:text-slate-100">
+        {totalQuestions > 1 ? (
+          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-[4px] px-1 text-xs font-medium text-slate-400 dark:text-slate-500">
+            {questionIndex}
+          </span>
+        ) : null}
+        <span className="font-medium">{question.title}</span>
+      </div>
+      {question.description ? (
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {question.description}
+        </p>
+      ) : null}
+
+      {question.kind !== 'text' && options.length > 0 ? (
+        <div className="space-y-px">
+          {options.map((option, idx) => {
+            const checked = selectedIds.includes(option.id);
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => {
+                  if (question.kind === 'single') {
+                    setSelectedIds([option.id]);
+                    if (customEnabled) setCustomText('');
+                  } else {
+                    toggleMulti(option.id);
+                  }
+                }}
+                className={optionRowBase}
+              >
+                <span className={cn(badgeBase, checked ? badgeOn : badgeOff)}>
+                  {optionBadge(idx)}
+                </span>
+                <span className="text-sm text-slate-800 dark:text-slate-100">
+                  {option.label}
+                  {option.description ? (
+                    <span className="text-slate-400 dark:text-slate-500">
+                      {' '}
+                      {option.description}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+
+          {customEnabled ? (
+            <div className="flex items-center gap-2 pt-1">
+              <span
+                className={cn(
+                  badgeBase,
+                  selectedIds.includes(QUESTION_CUSTOM_ID) ? badgeOn : badgeOff,
+                )}
+              >
+                {optionBadge(options.length)}
+              </span>
+              <input
+                value={customText}
+                onChange={(e) => handleCustomTextChange(e.target.value)}
+                placeholder={t('chat.question.customPlaceholder', 'Other...')}
+                className="h-7 w-full rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 text-sm text-slate-800 dark:text-slate-100 outline-none focus:border-blue-400"
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {question.kind === 'text' ? (
+        <textarea
+          value={textValue}
+          onChange={(e) => setTextValue(e.target.value)}
+          placeholder={
+            question.placeholder ??
+            t('chat.question.textPlaceholder', 'Type your answer...')
+          }
+          rows={3}
+          className="w-full resize-y rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm text-slate-800 dark:text-slate-100 outline-none focus:border-blue-400"
+        />
+      ) : null}
+
+      <div className="flex items-center justify-end gap-1.5">
+        {allowSkip ? (
+          <button
+            type="button"
+            onClick={() => onSubmit({ kind: 'skip' })}
+            className="h-6 rounded-[4px] px-2 text-sm text-slate-400 dark:text-slate-500 transition-colors hover:bg-slate-100 dark:hover:bg-white/10 hover:text-slate-700 dark:hover:text-slate-200"
+          >
+            {t('chat.question.skip', 'Skip')}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="h-6 rounded-[4px] bg-blue-500 px-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-600 disabled:opacity-50"
+        >
+          {isLast
+            ? t('chat.question.confirm', 'Confirm')
+            : t('chat.question.next', 'Next')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Stepped question card. Renders one question at a time, collects each answer,
+ * and calls `onComplete` with the full list once every question is answered.
+ * After completion (or if `answered` is set for a restored history card) it
+ * shows a compact read-only summary instead of the interactive prompt.
+ */
+export function QuestionCard({
+  questions,
+  answered = false,
+  onComplete,
+}: {
+  questions: QuestionConfig[];
+  /** When true, render the read-only summary (e.g. a question already answered
+   *  in a previous turn, restored from history). */
+  answered?: boolean;
+  onComplete?: (answers: QuestionAnswer[]) => void;
+}) {
+  const { t } = useTranslation();
+  const totalQuestions = questions.length;
+  const [index, setIndex] = useState(1);
+  const [answers, setAnswers] = useState<Record<number, QuestionAnswer>>({});
+  const [done, setDone] = useState(answered);
+
+  const clampedIndex = Math.max(1, Math.min(index, totalQuestions));
+  const question = questions[clampedIndex - 1];
+
+  const summaryText = useMemo(() => {
+    if (!done) return '';
+    return questions
+      .map((q, i) => {
+        const a = answers[i + 1];
+        if (!a || a.kind === 'skip')
+          return `${q.title}: ${t('chat.question.skipped', 'skipped')}`;
+        if (a.kind === 'text') return `${q.title}: ${a.text ?? ''}`;
+        const labels = (a.selectedIds ?? [])
+          .map((id) => q.options?.find((o) => o.id === id)?.label ?? id)
+          .filter(Boolean);
+        const parts = [...labels];
+        if (a.text) parts.push(a.text);
+        return `${q.title}: ${parts.join(', ') || t('chat.question.answered', 'answered')}`;
+      })
+      .join(' · ');
+  }, [done, questions, answers, t]);
+
+  if (!question) return null;
+
+  return (
+    <div className="overflow-hidden rounded-[10px] border border-blue-200 dark:border-blue-900/50 bg-blue-50/60 dark:bg-blue-900/10">
+      <div className="flex h-7 items-center justify-between border-b border-blue-100 dark:border-blue-900/40 px-3 text-xs">
+        <span className="font-semibold text-blue-600 dark:text-blue-400">
+          {t('chat.question.header', 'Please choose')}
+        </span>
+        {totalQuestions > 1 && !done ? (
+          <span className="text-slate-400 dark:text-slate-500">
+            {clampedIndex} / {totalQuestions}
+          </span>
+        ) : null}
+      </div>
+
+      {done ? (
+        <div className="bg-white/60 dark:bg-slate-800/40 px-3 py-2 text-xs text-slate-500 dark:text-slate-400">
+          {summaryText ||
+            t('chat.question.answeredHint', 'This question was answered.')}
+        </div>
+      ) : (
+        <QuestionPrompt
+          key={`${clampedIndex}-${question.title}`}
+          question={question}
+          questionIndex={clampedIndex}
+          totalQuestions={totalQuestions}
+          onSubmit={(answer) => {
+            const next = { ...answers, [clampedIndex]: answer };
+            setAnswers(next);
+            if (clampedIndex < totalQuestions) {
+              setIndex((i) => Math.min(totalQuestions, i + 1));
+            } else {
+              setDone(true);
+              onComplete?.(
+                questions.map((_, i) => next[i + 1] ?? { kind: 'skip' }),
+              );
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ChatPanel/ToolResultCard.tsx
+++ b/packages/frontend/src/components/ChatPanel/ToolResultCard.tsx
@@ -2,6 +2,12 @@ import { useTranslation } from 'react-i18next';
 import { Check, Eye } from 'lucide-react';
 import { getToolEntry, isRegisteredTool } from './toolRegistry';
 import { formatToolDisplayName } from './utils';
+import { ChatChartCard, parseChartSpec } from './chat-charts';
+import {
+  QuestionCard,
+  parseAskSpec,
+  formatAnswersForAgent,
+} from './QuestionCard';
 import type {
   ToolResultImage,
   ToolResultSource,
@@ -38,6 +44,10 @@ interface ToolResultCardProps {
   }) => void;
   onGraphView?: (data: GraphSearchResult) => void;
   documents?: Document[];
+  /** Send the user's answer to an ask_user question as the next message. */
+  onAnswer?: (content: string) => void;
+  /** True for restored-from-history question cards (render read-only). */
+  answered?: boolean;
 }
 
 export default function ToolResultCard({
@@ -56,6 +66,8 @@ export default function ToolResultCard({
   onViewDetails,
   onGraphView,
   documents = [],
+  onAnswer,
+  answered,
 }: ToolResultCardProps) {
   const { t } = useTranslation();
   const entry = getToolEntry(toolName, resultType === 'artifact');
@@ -63,6 +75,28 @@ export default function ToolResultCard({
   const displayName = toolName
     ? formatToolDisplayName(toolName)
     : 'Tool Result';
+
+  // render_chart tool result: draw the inline chart card instead of a pill.
+  // Degrades silently to the normal rendering if the spec doesn't validate.
+  const chartSpec = parseChartSpec(content);
+  if (chartSpec) {
+    return <ChatChartCard spec={chartSpec} />;
+  }
+
+  // ask_user tool result: draw the inline question card. On completion the
+  // answer is posted back as the user's next message (onAnswer).
+  const askSpec = parseAskSpec(content);
+  if (askSpec) {
+    return (
+      <QuestionCard
+        questions={askSpec.questions}
+        answered={answered}
+        onComplete={(answers) =>
+          onAnswer?.(formatAnswersForAgent(askSpec.questions, answers))
+        }
+      />
+    );
+  }
 
   // Build a summary label
   const summaryLabel = buildSummaryLabel(

--- a/packages/frontend/src/components/ChatPanel/chat-charts/CompareBars.tsx
+++ b/packages/frontend/src/components/ChatPanel/chat-charts/CompareBars.tsx
@@ -1,0 +1,164 @@
+import { cn } from '../../../lib/utils';
+import type { ChartCompareRow } from './types';
+
+/**
+ * Side-by-side compare chart - one row per metric, N bars per row. The bar
+ * widths within a row normalize against that row's largest value so
+ * cross-metric comparison stays visually fair.
+ */
+
+const TONE_CLASS: Record<
+  NonNullable<ChartCompareRow['values'][number]['tone']>,
+  string
+> = {
+  ok: 'bg-blue-500',
+  warn: 'bg-amber-400',
+  danger: 'bg-rose-500',
+};
+
+const SERIES_PALETTE = [
+  'bg-sky-400',
+  'bg-violet-400',
+  'bg-emerald-400',
+  'bg-amber-400',
+  'bg-rose-400',
+];
+
+export function CompareBars({
+  title,
+  subtitle,
+  note,
+  series,
+}: {
+  title: string;
+  subtitle?: string;
+  note?: string;
+  series: ChartCompareRow[];
+}) {
+  // Collect unique series names from all rows for a stable legend.
+  const legend: string[] = [];
+  for (const row of series) {
+    for (const v of row.values) {
+      if (!legend.includes(v.name)) legend.push(v.name);
+    }
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
+      <header className="border-b border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate text-[12px] font-bold leading-tight text-slate-800 dark:text-slate-100">
+              {title}
+            </div>
+            {subtitle ? (
+              <div className="mt-0.5 text-[10.5px] text-slate-500 dark:text-slate-400">
+                {subtitle}
+              </div>
+            ) : null}
+          </div>
+          {legend.length > 1 ? (
+            <div className="flex shrink-0 items-center gap-1.5">
+              {legend.map((name, i) => (
+                <span
+                  key={name}
+                  className="inline-flex items-center gap-1 text-[10px] text-slate-500 dark:text-slate-400"
+                >
+                  <span
+                    className={cn(
+                      'inline-block h-2 w-2 rounded-sm',
+                      SERIES_PALETTE[i % SERIES_PALETTE.length],
+                    )}
+                  />
+                  {name}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </header>
+      <div className="flex flex-col gap-2 px-3 py-2">
+        {series.map((row, i) => {
+          const rowMax = Math.max(...row.values.map((v) => v.value || 0), 1);
+          return (
+            <div key={`${row.label}-${i}`} className="flex flex-col gap-1">
+              <div className="flex items-center justify-between text-[10.5px]">
+                <span className="font-semibold text-slate-500 dark:text-slate-400">
+                  {row.label}
+                </span>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                {row.values.map((v, idx) => {
+                  const pct = Math.max(0, Math.min(1, v.value / rowMax)) * 100;
+                  // Tone wins over the legend palette so danger/warn rows
+                  // stand out even in a multi-series chart.
+                  const cls = v.tone
+                    ? TONE_CLASS[v.tone]
+                    : SERIES_PALETTE[
+                        legend.indexOf(v.name) %
+                          Math.max(SERIES_PALETTE.length, 1)
+                      ] || 'bg-blue-500';
+                  return (
+                    <div
+                      key={`${v.name}-${idx}`}
+                      className="grid grid-cols-[60px_1fr_80px] items-center gap-2"
+                    >
+                      <span
+                        className="truncate text-[10px] text-slate-400 dark:text-slate-500"
+                        title={v.name}
+                      >
+                        {v.name}
+                      </span>
+                      <div className="relative h-2 rounded-full bg-slate-100 dark:bg-white/10">
+                        <div
+                          className={cn(
+                            'h-full rounded-full transition-[width] duration-500 ease-out',
+                            cls,
+                          )}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <span
+                        className={cn(
+                          'text-right font-mono text-[10.5px] tabular-nums leading-none',
+                          v.tone === 'danger'
+                            ? 'text-rose-600 dark:text-rose-400 font-bold'
+                            : v.tone === 'warn'
+                              ? 'text-amber-600 dark:text-amber-400 font-semibold'
+                              : 'text-slate-800 dark:text-slate-100',
+                        )}
+                      >
+                        {formatNumber(v.value)}
+                        {row.unit ? (
+                          <span className="ml-0.5 text-[9px] text-slate-400 dark:text-slate-500">
+                            {row.unit}
+                          </span>
+                        ) : null}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {note ? (
+        <footer className="border-t border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1 text-[9.5px] text-slate-400 dark:text-slate-500">
+          {note}
+        </footer>
+      ) : null}
+    </div>
+  );
+}
+
+function formatNumber(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (Math.abs(n) >= 10_000) return `${(n / 1000).toFixed(1)}k`;
+  if (Math.abs(n) >= 1) {
+    return n.toLocaleString(undefined, {
+      maximumFractionDigits: Math.abs(n) >= 100 ? 0 : 1,
+    });
+  }
+  return n.toFixed(2);
+}

--- a/packages/frontend/src/components/ChatPanel/chat-charts/DonutChart.tsx
+++ b/packages/frontend/src/components/ChatPanel/chat-charts/DonutChart.tsx
@@ -1,0 +1,149 @@
+import type { ChartDonutSlice } from './types';
+
+/**
+ * Donut chart card - composition / share of a whole. Pure SVG: each slice is
+ * an arc drawn with stroke-dasharray on a circle, the total sits in the center,
+ * and a legend lists each category with its percentage. No charting deps.
+ */
+
+// Hex values (not Tailwind classes) because SVG stroke needs a concrete color.
+const TONE_HEX: Record<NonNullable<ChartDonutSlice['tone']>, string> = {
+  ok: '#3b82f6', // blue-500
+  warn: '#f59e0b', // amber-500
+  danger: '#ef4444', // rose-500
+};
+
+const PALETTE = [
+  '#3b82f6', // blue-500
+  '#8b5cf6', // violet-500
+  '#10b981', // emerald-500
+  '#f59e0b', // amber-500
+  '#ef4444', // rose-500
+  '#06b6d4', // cyan-500
+  '#ec4899', // pink-500
+];
+
+const RADIUS = 42;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function DonutChart({
+  title,
+  subtitle,
+  note,
+  unit = '',
+  series,
+}: {
+  title: string;
+  subtitle?: string;
+  note?: string;
+  unit?: string;
+  series: ChartDonutSlice[];
+}) {
+  const total = series.reduce((sum, s) => sum + (s.value || 0), 0) || 1;
+
+  // Precompute each slice's color, fraction, and dash offset so the arcs sit
+  // end-to-end around the ring.
+  let acc = 0;
+  const slices = series.map((s, i) => {
+    const frac = (s.value || 0) / total;
+    const color = s.tone ? TONE_HEX[s.tone] : PALETTE[i % PALETTE.length];
+    const dash = frac * CIRCUMFERENCE;
+    const offset = acc * CIRCUMFERENCE;
+    acc += frac;
+    return { ...s, frac, color, dash, offset };
+  });
+
+  return (
+    <div className="overflow-hidden rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
+      <header className="border-b border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1.5">
+        <div className="text-[12px] font-bold leading-tight text-slate-800 dark:text-slate-100">
+          {title}
+        </div>
+        {subtitle ? (
+          <div className="mt-0.5 text-[10.5px] text-slate-500 dark:text-slate-400">
+            {subtitle}
+          </div>
+        ) : null}
+      </header>
+      <div className="flex items-center gap-4 px-3 py-3">
+        <div className="relative shrink-0" style={{ width: 104, height: 104 }}>
+          <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
+            <circle
+              cx="50"
+              cy="50"
+              r={RADIUS}
+              fill="none"
+              className="stroke-slate-100 dark:stroke-white/10"
+              strokeWidth="12"
+            />
+            {slices.map((s, i) => (
+              <circle
+                key={`${s.label}-${i}`}
+                cx="50"
+                cy="50"
+                r={RADIUS}
+                fill="none"
+                stroke={s.color}
+                strokeWidth="12"
+                strokeDasharray={`${s.dash} ${CIRCUMFERENCE - s.dash}`}
+                strokeDashoffset={-s.offset}
+                className="transition-[stroke-dasharray] duration-500 ease-out"
+              />
+            ))}
+          </svg>
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="font-mono text-[13px] font-bold tabular-nums leading-none text-slate-800 dark:text-slate-100">
+              {formatNumber(total)}
+            </span>
+            {unit ? (
+              <span className="mt-0.5 text-[9px] text-slate-400 dark:text-slate-500">
+                {unit}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          {slices.map((s, i) => (
+            <div
+              key={`${s.label}-legend-${i}`}
+              className="grid grid-cols-[10px_1fr_auto] items-center gap-2 text-[11px]"
+            >
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-sm"
+                style={{ backgroundColor: s.color }}
+              />
+              <span
+                className="truncate text-slate-600 dark:text-slate-300"
+                title={s.label}
+              >
+                {s.label}
+              </span>
+              <span className="text-right font-mono tabular-nums leading-none text-slate-800 dark:text-slate-100">
+                {formatNumber(s.value)}
+                <span className="ml-1 text-[9px] text-slate-400 dark:text-slate-500">
+                  {(s.frac * 100).toFixed(1)}%
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {note ? (
+        <footer className="border-t border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1 text-[9.5px] text-slate-400 dark:text-slate-500">
+          {note}
+        </footer>
+      ) : null}
+    </div>
+  );
+}
+
+function formatNumber(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (Math.abs(n) >= 10_000) return `${(n / 1000).toFixed(1)}k`;
+  if (Math.abs(n) >= 1) {
+    return n.toLocaleString(undefined, {
+      maximumFractionDigits: Math.abs(n) >= 100 ? 0 : 1,
+    });
+  }
+  return n.toFixed(2);
+}

--- a/packages/frontend/src/components/ChatPanel/chat-charts/HBarChart.tsx
+++ b/packages/frontend/src/components/ChatPanel/chat-charts/HBarChart.tsx
@@ -1,0 +1,121 @@
+import { cn } from '../../../lib/utils';
+import type { ChartBarRow } from './types';
+
+/**
+ * Horizontal-bar chart card - one bar per metric, value compared against an
+ * optional cap. Pure CSS, no charting deps. Embedded inside an assistant
+ * message right after the prose summary so the number AND the visual read at
+ * one glance.
+ */
+
+const TONE_CLASS: Record<NonNullable<ChartBarRow['tone']>, string> = {
+  ok: 'bg-blue-500',
+  warn: 'bg-amber-400',
+  danger: 'bg-rose-500',
+};
+
+export function HBarChart({
+  title,
+  subtitle,
+  note,
+  series,
+}: {
+  title: string;
+  subtitle?: string;
+  note?: string;
+  series: ChartBarRow[];
+}) {
+  // Fallback scale when no row carries a `max`: largest value renders
+  // full-width and the rest scale proportionally.
+  const fallbackMax = Math.max(...series.map((s) => s.value || 0), 1);
+
+  return (
+    <div className="overflow-hidden rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
+      <header className="border-b border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1.5">
+        <div className="text-[12px] font-bold leading-tight text-slate-800 dark:text-slate-100">
+          {title}
+        </div>
+        {subtitle ? (
+          <div className="mt-0.5 text-[10.5px] text-slate-500 dark:text-slate-400">
+            {subtitle}
+          </div>
+        ) : null}
+      </header>
+      <div className="flex flex-col gap-1.5 px-3 py-2">
+        {series.map((row, i) => {
+          const cap = row.max && row.max > 0 ? row.max : fallbackMax;
+          const pct = Math.max(0, Math.min(1, (row.value || 0) / cap)) * 100;
+          const tone =
+            row.tone ?? (row.max && row.value > row.max ? 'danger' : 'ok');
+          return (
+            <div
+              key={`${row.label}-${i}`}
+              className="grid grid-cols-[64px_1fr_80px] items-center gap-2 text-[11px]"
+            >
+              <span
+                className="truncate text-slate-500 dark:text-slate-400"
+                title={row.label}
+              >
+                {row.label}
+              </span>
+              <div className="relative h-2 rounded-full bg-slate-100 dark:bg-white/10">
+                <div
+                  className={cn(
+                    'h-full rounded-full transition-[width] duration-500 ease-out',
+                    TONE_CLASS[tone],
+                  )}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <span
+                className={cn(
+                  'text-right font-mono tabular-nums leading-none',
+                  tone === 'danger'
+                    ? 'text-rose-600 dark:text-rose-400 font-bold'
+                    : tone === 'warn'
+                      ? 'text-amber-600 dark:text-amber-400 font-semibold'
+                      : 'text-slate-800 dark:text-slate-100',
+                )}
+                title={
+                  row.max ? `${row.value} / ${row.max}` : String(row.value)
+                }
+              >
+                {formatNumber(row.value)}
+                {row.unit ? (
+                  <span className="ml-0.5 text-[9.5px] text-slate-400 dark:text-slate-500">
+                    {row.unit}
+                  </span>
+                ) : null}
+                {row.max ? (
+                  <span className="ml-0.5 text-[9px] text-slate-400 dark:text-slate-500">
+                    /{formatNumber(row.max)}
+                  </span>
+                ) : null}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {note ? (
+        <footer className="border-t border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1 text-[9.5px] text-slate-400 dark:text-slate-500">
+          {note}
+        </footer>
+      ) : null}
+    </div>
+  );
+}
+
+/** Compact number formatting - keeps mid-range values readable ("1,800" not
+ *  "1800") while shortening large values ("12k" not "12000"). */
+function formatNumber(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (Math.abs(n) >= 10_000) {
+    return `${(n / 1000).toFixed(1)}k`;
+  }
+  if (Math.abs(n) >= 1) {
+    return n.toLocaleString(undefined, {
+      maximumFractionDigits: Math.abs(n) >= 100 ? 0 : 1,
+    });
+  }
+  return n.toFixed(2);
+}

--- a/packages/frontend/src/components/ChatPanel/chat-charts/ScatterChart.tsx
+++ b/packages/frontend/src/components/ChatPanel/chat-charts/ScatterChart.tsx
@@ -1,0 +1,164 @@
+import type { ChartScatterPoint } from './types';
+
+/**
+ * Scatter chart card - points on an X/Y plane to show the correlation between
+ * two numeric variables. Pure SVG: points are normalized against the data's
+ * min/max on each axis, with light gridlines and axis labels. No charting deps.
+ */
+
+const TONE_HEX: Record<NonNullable<ChartScatterPoint['tone']>, string> = {
+  ok: '#3b82f6', // blue-500
+  warn: '#f59e0b', // amber-500
+  danger: '#ef4444', // rose-500
+};
+
+// Viewbox geometry: leave margins for axis labels.
+const W = 260;
+const H = 160;
+const PAD_L = 28;
+const PAD_B = 22;
+const PAD_T = 8;
+const PAD_R = 8;
+
+export function ScatterChart({
+  title,
+  subtitle,
+  note,
+  xLabel,
+  yLabel,
+  series,
+}: {
+  title: string;
+  subtitle?: string;
+  note?: string;
+  xLabel?: string;
+  yLabel?: string;
+  series: ChartScatterPoint[];
+}) {
+  const xs = series.map((p) => p.x).filter(Number.isFinite);
+  const ys = series.map((p) => p.y).filter(Number.isFinite);
+  const xMin = Math.min(...xs);
+  const xMax = Math.max(...xs);
+  const yMin = Math.min(...ys);
+  const yMax = Math.max(...ys);
+  const xSpan = xMax - xMin || 1;
+  const ySpan = yMax - yMin || 1;
+
+  const plotW = W - PAD_L - PAD_R;
+  const plotH = H - PAD_T - PAD_B;
+  const px = (x: number) => PAD_L + ((x - xMin) / xSpan) * plotW;
+  const py = (y: number) => PAD_T + (1 - (y - yMin) / ySpan) * plotH;
+
+  return (
+    <div className="overflow-hidden rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
+      <header className="border-b border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1.5">
+        <div className="text-[12px] font-bold leading-tight text-slate-800 dark:text-slate-100">
+          {title}
+        </div>
+        {subtitle ? (
+          <div className="mt-0.5 text-[10.5px] text-slate-500 dark:text-slate-400">
+            {subtitle}
+          </div>
+        ) : null}
+      </header>
+      <div className="px-2 py-2">
+        <svg viewBox={`0 0 ${W} ${H}`} className="w-full">
+          {/* Axes */}
+          <line
+            x1={PAD_L}
+            y1={PAD_T}
+            x2={PAD_L}
+            y2={H - PAD_B}
+            className="stroke-slate-200 dark:stroke-slate-600"
+            strokeWidth="1"
+          />
+          <line
+            x1={PAD_L}
+            y1={H - PAD_B}
+            x2={W - PAD_R}
+            y2={H - PAD_B}
+            className="stroke-slate-200 dark:stroke-slate-600"
+            strokeWidth="1"
+          />
+          {/* Axis min/max ticks */}
+          <text
+            x={PAD_L}
+            y={H - PAD_B + 12}
+            className="fill-slate-400 dark:fill-slate-500"
+            fontSize="7"
+            textAnchor="start"
+          >
+            {formatNumber(xMin)}
+          </text>
+          <text
+            x={W - PAD_R}
+            y={H - PAD_B + 12}
+            className="fill-slate-400 dark:fill-slate-500"
+            fontSize="7"
+            textAnchor="end"
+          >
+            {formatNumber(xMax)}
+          </text>
+          <text
+            x={PAD_L - 3}
+            y={H - PAD_B}
+            className="fill-slate-400 dark:fill-slate-500"
+            fontSize="7"
+            textAnchor="end"
+          >
+            {formatNumber(yMin)}
+          </text>
+          <text
+            x={PAD_L - 3}
+            y={PAD_T + 6}
+            className="fill-slate-400 dark:fill-slate-500"
+            fontSize="7"
+            textAnchor="end"
+          >
+            {formatNumber(yMax)}
+          </text>
+          {/* Points */}
+          {series.map((p, i) =>
+            Number.isFinite(p.x) && Number.isFinite(p.y) ? (
+              <circle
+                key={i}
+                cx={px(p.x)}
+                cy={py(p.y)}
+                r="2.8"
+                fill={p.tone ? TONE_HEX[p.tone] : '#3b82f6'}
+                fillOpacity="0.7"
+              >
+                <title>
+                  {p.label ? `${p.label}: ` : ''}
+                  {`(${formatNumber(p.x)}, ${formatNumber(p.y)})`}
+                </title>
+              </circle>
+            ) : null,
+          )}
+        </svg>
+        {(xLabel || yLabel) && (
+          <div className="mt-1 flex items-center justify-between px-1 text-[9px] text-slate-400 dark:text-slate-500">
+            <span>{yLabel ? `↑ ${yLabel}` : ''}</span>
+            <span>{xLabel ? `${xLabel} →` : ''}</span>
+          </div>
+        )}
+      </div>
+      {note ? (
+        <footer className="border-t border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1 text-[9.5px] text-slate-400 dark:text-slate-500">
+          {note}
+        </footer>
+      ) : null}
+    </div>
+  );
+}
+
+function formatNumber(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (Math.abs(n) >= 10_000) return `${(n / 1000).toFixed(1)}k`;
+  if (Math.abs(n) >= 1) {
+    return n.toLocaleString(undefined, {
+      maximumFractionDigits: Math.abs(n) >= 100 ? 0 : 1,
+    });
+  }
+  return n.toFixed(2);
+}

--- a/packages/frontend/src/components/ChatPanel/chat-charts/StackedBars.tsx
+++ b/packages/frontend/src/components/ChatPanel/chat-charts/StackedBars.tsx
@@ -1,0 +1,155 @@
+import { cn } from '../../../lib/utils';
+import type { ChartStackedRow } from './types';
+
+/**
+ * Vertical stacked-bar chart card - each label gets one bar split into named
+ * segments stacked on top of each other. Bars normalize against the tallest
+ * total so part-to-whole comparison across categories stays fair. Pure CSS/
+ * flex, no charting deps.
+ */
+
+const TONE_CLASS: Record<
+  NonNullable<ChartStackedRow['segments'][number]['tone']>,
+  string
+> = {
+  ok: 'bg-blue-500',
+  warn: 'bg-amber-400',
+  danger: 'bg-rose-500',
+};
+
+const SERIES_PALETTE = [
+  'bg-sky-400',
+  'bg-violet-400',
+  'bg-emerald-400',
+  'bg-amber-400',
+  'bg-rose-400',
+];
+
+const BAR_AREA_PX = 140;
+
+export function StackedBars({
+  title,
+  subtitle,
+  note,
+  series,
+}: {
+  title: string;
+  subtitle?: string;
+  note?: string;
+  series: ChartStackedRow[];
+}) {
+  // Stable legend from the first appearance of each segment name.
+  const legend: string[] = [];
+  for (const row of series) {
+    for (const seg of row.segments) {
+      if (!legend.includes(seg.name)) legend.push(seg.name);
+    }
+  }
+  const colorFor = (name: string, tone?: 'ok' | 'warn' | 'danger') =>
+    tone
+      ? TONE_CLASS[tone]
+      : SERIES_PALETTE[legend.indexOf(name) % SERIES_PALETTE.length] ||
+        'bg-blue-500';
+
+  const maxTotal = Math.max(
+    ...series.map((r) => r.segments.reduce((s, x) => s + (x.value || 0), 0)),
+    1,
+  );
+
+  return (
+    <div className="overflow-hidden rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
+      <header className="border-b border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate text-[12px] font-bold leading-tight text-slate-800 dark:text-slate-100">
+              {title}
+            </div>
+            {subtitle ? (
+              <div className="mt-0.5 text-[10.5px] text-slate-500 dark:text-slate-400">
+                {subtitle}
+              </div>
+            ) : null}
+          </div>
+          {legend.length > 1 ? (
+            <div className="flex shrink-0 flex-wrap items-center gap-1.5">
+              {legend.map((name, i) => (
+                <span
+                  key={name}
+                  className="inline-flex items-center gap-1 text-[10px] text-slate-500 dark:text-slate-400"
+                >
+                  <span
+                    className={cn(
+                      'inline-block h-2 w-2 rounded-sm',
+                      SERIES_PALETTE[i % SERIES_PALETTE.length],
+                    )}
+                  />
+                  {name}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </header>
+      <div
+        className="flex items-end justify-around gap-3 px-3 pt-3"
+        style={{ height: BAR_AREA_PX + 24 }}
+      >
+        {series.map((row, i) => {
+          const total = row.segments.reduce((s, x) => s + (x.value || 0), 0);
+          const barH = (total / maxTotal) * BAR_AREA_PX;
+          return (
+            <div
+              key={`${row.label}-${i}`}
+              className="flex min-w-0 flex-1 flex-col items-center gap-1"
+            >
+              <span className="font-mono text-[9px] tabular-nums text-slate-400 dark:text-slate-500">
+                {formatNumber(total)}
+              </span>
+              <div
+                className="flex w-full max-w-12 flex-col overflow-hidden rounded"
+                style={{ height: barH }}
+                title={`${row.label}: ${formatNumber(total)}`}
+              >
+                {row.segments.map((seg, si) => {
+                  const h = total > 0 ? ((seg.value || 0) / total) * 100 : 0;
+                  return (
+                    <div
+                      key={`${seg.name}-${si}`}
+                      className={cn(colorFor(seg.name, seg.tone))}
+                      style={{ height: `${h}%` }}
+                      title={`${seg.name}: ${formatNumber(seg.value)}${row.unit ? ' ' + row.unit : ''}`}
+                    />
+                  );
+                })}
+              </div>
+              <span
+                className="max-w-full truncate text-[10px] text-slate-500 dark:text-slate-400"
+                title={row.label}
+              >
+                {row.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {note ? (
+        <footer className="mt-1 border-t border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1 text-[9.5px] text-slate-400 dark:text-slate-500">
+          {note}
+        </footer>
+      ) : (
+        <div className="h-2" />
+      )}
+    </div>
+  );
+}
+
+function formatNumber(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (Math.abs(n) >= 10_000) return `${(n / 1000).toFixed(1)}k`;
+  if (Math.abs(n) >= 1) {
+    return n.toLocaleString(undefined, {
+      maximumFractionDigits: Math.abs(n) >= 100 ? 0 : 1,
+    });
+  }
+  return n.toFixed(2);
+}

--- a/packages/frontend/src/components/ChatPanel/chat-charts/TimelineChart.tsx
+++ b/packages/frontend/src/components/ChatPanel/chat-charts/TimelineChart.tsx
@@ -1,0 +1,182 @@
+import { useTranslation } from 'react-i18next';
+import { cn } from '../../../lib/utils';
+import type { ChartTimelinePoint } from './types';
+
+/**
+ * Vertical timeline chart - a value over time. Each point is one row
+ * [date | bar | value], and between consecutive rows a connector shows the
+ * day gap so the reader sees both "how much" and "how long between" in one
+ * card. Bars normalize against the largest realized value; a null value (an
+ * upcoming, not-yet-realized point) renders a muted "scheduled" pill. The gap
+ * is computed from the two ISO dates here, so the LLM payload stays date +
+ * value.
+ */
+
+const TONE_BAR: Record<NonNullable<ChartTimelinePoint['tone']>, string> = {
+  ok: 'bg-blue-500',
+  warn: 'bg-amber-400',
+  danger: 'bg-rose-500',
+};
+
+const TONE_TEXT: Record<NonNullable<ChartTimelinePoint['tone']>, string> = {
+  ok: 'text-slate-800 dark:text-slate-100',
+  warn: 'text-amber-600 dark:text-amber-400 font-semibold',
+  danger: 'text-rose-600 dark:text-rose-400 font-bold',
+};
+
+export function TimelineChart({
+  title,
+  subtitle,
+  note,
+  unit = '',
+  series,
+}: {
+  title: string;
+  subtitle?: string;
+  note?: string;
+  unit?: string;
+  series: ChartTimelinePoint[];
+}) {
+  const { t } = useTranslation();
+  const realized = series
+    .map((p) => p.value)
+    .filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+  // Fallback to 1 so an all-pending timeline still renders rows.
+  const barMax = Math.max(...realized, 1);
+
+  return (
+    <div className="overflow-hidden rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm">
+      <header className="border-b border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1.5">
+        <div className="text-[12px] font-bold leading-tight text-slate-800 dark:text-slate-100">
+          {title}
+        </div>
+        {subtitle ? (
+          <div className="mt-0.5 text-[10.5px] text-slate-500 dark:text-slate-400">
+            {subtitle}
+          </div>
+        ) : null}
+      </header>
+      <div className="px-3 py-2">
+        {series.map((point, i) => {
+          const next = series[i + 1];
+          const gap = next ? dayGap(point.date, next.date) : null;
+          const hasValue =
+            typeof point.value === 'number' && Number.isFinite(point.value);
+          const tone = point.tone ?? 'ok';
+          const pct = hasValue
+            ? Math.max(0, Math.min(1, (point.value as number) / barMax)) * 100
+            : 0;
+          return (
+            <div key={`${point.date}-${i}`}>
+              <div className="grid grid-cols-[80px_1fr_auto] items-center gap-2 text-[11px]">
+                <span
+                  className="font-mono tabular-nums text-[10px] text-slate-500 dark:text-slate-400"
+                  title={point.date}
+                >
+                  {formatDate(point.date)}
+                </span>
+                <div className="relative h-2 rounded-full bg-slate-100 dark:bg-white/10">
+                  {hasValue ? (
+                    <div
+                      className={cn(
+                        'h-full rounded-full transition-[width] duration-500 ease-out',
+                        TONE_BAR[tone],
+                      )}
+                      style={{ width: `${pct}%` }}
+                    />
+                  ) : null}
+                </div>
+                <span className="flex items-center justify-end gap-1 text-right">
+                  {hasValue ? (
+                    <span
+                      className={cn(
+                        'font-mono tabular-nums leading-none',
+                        TONE_TEXT[tone],
+                      )}
+                    >
+                      {formatNumber(point.value as number)}
+                      {unit ? (
+                        <span className="ml-0.5 text-[9px] text-slate-400 dark:text-slate-500">
+                          {unit}
+                        </span>
+                      ) : null}
+                    </span>
+                  ) : (
+                    <span className="rounded-sm bg-slate-100 dark:bg-white/10 px-1 py-px text-[9.5px] text-slate-400 dark:text-slate-500">
+                      {t('chat.chart.scheduled', 'Scheduled')}
+                    </span>
+                  )}
+                  {point.tag ? (
+                    <span
+                      className={cn(
+                        'rounded-sm px-1 py-px text-[9px] font-semibold',
+                        tone === 'danger'
+                          ? 'bg-rose-50 dark:bg-rose-900/30 text-rose-600 dark:text-rose-400'
+                          : tone === 'warn'
+                            ? 'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
+                            : 'bg-slate-100 dark:bg-white/10 text-slate-400 dark:text-slate-500',
+                      )}
+                    >
+                      {point.tag}
+                    </span>
+                  ) : null}
+                </span>
+              </div>
+              {next ? (
+                <div className="flex items-center gap-2 py-0.5 pl-4">
+                  <span
+                    aria-hidden
+                    className="h-3 w-px bg-slate-200 dark:bg-slate-700"
+                  />
+                  {gap !== null ? (
+                    <span className="text-[9.5px] text-slate-400 dark:text-slate-500">
+                      {t('chat.chart.dayGap', '{{count}}d gap', { count: gap })}
+                    </span>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      {note ? (
+        <footer className="border-t border-slate-200/60 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/60 px-3 py-1 text-[9.5px] text-slate-400 dark:text-slate-500">
+          {note}
+        </footer>
+      ) : null}
+    </div>
+  );
+}
+
+/** Whole-day gap between two ISO "YYYY-MM-DD" dates, or null if either fails
+ *  to parse. Parsed as UTC midnight so DST shifts can't round the difference. */
+function dayGap(a: string, b: string): number | null {
+  const da = parseIsoDay(a);
+  const db = parseIsoDay(b);
+  if (da === null || db === null) return null;
+  return Math.round((db - da) / 86_400_000);
+}
+
+function parseIsoDay(s: string): number | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+  if (!m) return null;
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+}
+
+/** Normalize an ISO date to "YYYY-MM-DD" (dropping any time suffix); non-ISO
+ *  strings pass through unchanged. */
+function formatDate(s: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+  return m ? `${m[1]}-${m[2]}-${m[3]}` : s;
+}
+
+function formatNumber(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (Math.abs(n) >= 10_000) return `${(n / 1000).toFixed(1)}k`;
+  if (Math.abs(n) >= 1) {
+    return n.toLocaleString(undefined, {
+      maximumFractionDigits: Math.abs(n) >= 100 ? 0 : 1,
+    });
+  }
+  return n.toFixed(2);
+}

--- a/packages/frontend/src/components/ChatPanel/chat-charts/index.tsx
+++ b/packages/frontend/src/components/ChatPanel/chat-charts/index.tsx
@@ -1,0 +1,300 @@
+import { HBarChart } from './HBarChart';
+import { CompareBars } from './CompareBars';
+import { TimelineChart } from './TimelineChart';
+import { DonutChart } from './DonutChart';
+import { StackedBars } from './StackedBars';
+import { ScatterChart } from './ScatterChart';
+import type {
+  ChartBarRow,
+  ChartCompareRow,
+  ChartDonutSlice,
+  ChartScatterPoint,
+  ChartSpec,
+  ChartStackedRow,
+  ChartTimelinePoint,
+} from './types';
+
+/**
+ * Chart card dispatcher - picks the renderer for a `render_chart` tool result.
+ * Exposed as a single component so the chat panel only has to know about
+ * `<ChatChartCard spec={…} />`; new chart types plug in here.
+ *
+ * Spec validation is deliberately permissive - the LLM occasionally emits a
+ * malformed payload. We coerce what we can and bail out silently if there's
+ * nothing to draw, so a bad spec degrades to "the prose summary is enough"
+ * instead of crashing the message.
+ */
+export function ChatChartCard({ spec }: { spec: ChartSpec | null }) {
+  if (!spec) return null;
+  if (spec.type === 'hbar') {
+    return (
+      <HBarChart
+        title={spec.title}
+        subtitle={spec.subtitle}
+        note={spec.note}
+        series={spec.series}
+      />
+    );
+  }
+  if (spec.type === 'compare') {
+    return (
+      <CompareBars
+        title={spec.title}
+        subtitle={spec.subtitle}
+        note={spec.note}
+        series={spec.series}
+      />
+    );
+  }
+  if (spec.type === 'timeline') {
+    return (
+      <TimelineChart
+        title={spec.title}
+        subtitle={spec.subtitle}
+        note={spec.note}
+        unit={spec.unit}
+        series={spec.series}
+      />
+    );
+  }
+  if (spec.type === 'donut') {
+    return (
+      <DonutChart
+        title={spec.title}
+        subtitle={spec.subtitle}
+        note={spec.note}
+        unit={spec.unit}
+        series={spec.series}
+      />
+    );
+  }
+  if (spec.type === 'stacked') {
+    return (
+      <StackedBars
+        title={spec.title}
+        subtitle={spec.subtitle}
+        note={spec.note}
+        series={spec.series}
+      />
+    );
+  }
+  if (spec.type === 'scatter') {
+    return (
+      <ScatterChart
+        title={spec.title}
+        subtitle={spec.subtitle}
+        note={spec.note}
+        xLabel={spec.xLabel}
+        yLabel={spec.yLabel}
+        series={spec.series}
+      />
+    );
+  }
+  return null;
+}
+
+/** Parse a tool-result JSON string into a ChartSpec, or null if the payload
+ *  isn't a `render_chart` action or the shape doesn't validate. */
+export function parseChartSpec(
+  resultText: string | undefined,
+): ChartSpec | null {
+  if (!resultText) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(resultText);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  if (obj._ui_action !== 'render_chart') return null;
+  const chart = obj.chart;
+  if (!chart || typeof chart !== 'object') return null;
+  const c = chart as Record<string, unknown>;
+  const title = typeof c.title === 'string' ? c.title : '';
+  const subtitle = typeof c.subtitle === 'string' ? c.subtitle : undefined;
+  const note = typeof c.note === 'string' ? c.note : undefined;
+  const series = Array.isArray(c.series) ? c.series : [];
+  if (!title || series.length === 0) return null;
+
+  // Coerce per-type, then bail out (null) if EVERY row was rejected - a chart
+  // with no valid rows would render empty axes / NaN scales, so degrade to the
+  // prose summary instead.
+  if (c.type === 'hbar') {
+    const rows = series
+      .map(coerceBarRow)
+      .filter((r): r is ChartBarRow => r !== null);
+    if (rows.length === 0) return null;
+    return { type: 'hbar', title, subtitle, note, series: rows };
+  }
+  if (c.type === 'compare') {
+    const rows = series
+      .map(coerceCompareRow)
+      .filter((r): r is ChartCompareRow => r !== null);
+    if (rows.length === 0) return null;
+    return { type: 'compare', title, subtitle, note, series: rows };
+  }
+  if (c.type === 'timeline') {
+    const rows = series
+      .map(coerceTimelinePoint)
+      .filter((r): r is ChartTimelinePoint => r !== null);
+    if (rows.length === 0) return null;
+    return {
+      type: 'timeline',
+      title,
+      subtitle,
+      note,
+      unit: typeof c.unit === 'string' ? c.unit : undefined,
+      series: rows,
+    };
+  }
+  if (c.type === 'donut') {
+    const rows = series
+      .map(coerceDonutSlice)
+      .filter((r): r is ChartDonutSlice => r !== null);
+    if (rows.length === 0) return null;
+    return {
+      type: 'donut',
+      title,
+      subtitle,
+      note,
+      unit: typeof c.unit === 'string' ? c.unit : undefined,
+      series: rows,
+    };
+  }
+  if (c.type === 'stacked') {
+    const rows = series
+      .map(coerceStackedRow)
+      .filter((r): r is ChartStackedRow => r !== null);
+    if (rows.length === 0) return null;
+    return { type: 'stacked', title, subtitle, note, series: rows };
+  }
+  if (c.type === 'scatter') {
+    const rows = series
+      .map(coerceScatterPoint)
+      .filter((r): r is ChartScatterPoint => r !== null);
+    if (rows.length === 0) return null;
+    return {
+      type: 'scatter',
+      title,
+      subtitle,
+      note,
+      xLabel: typeof c.xLabel === 'string' ? c.xLabel : undefined,
+      yLabel: typeof c.yLabel === 'string' ? c.yLabel : undefined,
+      series: rows,
+    };
+  }
+  return null;
+}
+
+function coerceTone(t: unknown): 'ok' | 'warn' | 'danger' | undefined {
+  return t === 'ok' || t === 'warn' || t === 'danger' ? t : undefined;
+}
+
+function coerceBarRow(row: unknown): ChartBarRow | null {
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const label = typeof r.label === 'string' ? r.label : '';
+  const value = typeof r.value === 'number' ? r.value : Number(r.value);
+  if (!label || !Number.isFinite(value)) return null;
+  return {
+    label,
+    value,
+    max: typeof r.max === 'number' ? r.max : undefined,
+    unit: typeof r.unit === 'string' ? r.unit : undefined,
+    tone: coerceTone(r.tone),
+  };
+}
+
+function coerceCompareRow(row: unknown): ChartCompareRow | null {
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const label = typeof r.label === 'string' ? r.label : '';
+  const valuesRaw = Array.isArray(r.values) ? r.values : [];
+  const values: ChartCompareRow['values'] = valuesRaw
+    .map((v): ChartCompareRow['values'][number] | null => {
+      if (!v || typeof v !== 'object') return null;
+      const o = v as Record<string, unknown>;
+      const name = typeof o.name === 'string' ? o.name : '';
+      const value = typeof o.value === 'number' ? o.value : Number(o.value);
+      if (!name || !Number.isFinite(value)) return null;
+      return { name, value, tone: coerceTone(o.tone) };
+    })
+    .filter((x): x is ChartCompareRow['values'][number] => x !== null);
+  if (!label || values.length === 0) return null;
+  return {
+    label,
+    unit: typeof r.unit === 'string' ? r.unit : undefined,
+    values,
+  };
+}
+
+function coerceTimelinePoint(row: unknown): ChartTimelinePoint | null {
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const date = typeof r.date === 'string' ? r.date : '';
+  if (!date) return null;
+  // A null/missing value is intentional - it marks an upcoming (not-yet-
+  // realized) point, so coerce only when a real number is present.
+  let value: number | null = null;
+  if (typeof r.value === 'number' && Number.isFinite(r.value)) {
+    value = r.value;
+  } else if (typeof r.value === 'string' && r.value.trim() !== '') {
+    const n = Number(r.value);
+    value = Number.isFinite(n) ? n : null;
+  }
+  return {
+    date,
+    value,
+    tag: typeof r.tag === 'string' ? r.tag : undefined,
+    tone: coerceTone(r.tone),
+  };
+}
+
+function coerceDonutSlice(row: unknown): ChartDonutSlice | null {
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const label = typeof r.label === 'string' ? r.label : '';
+  const value = typeof r.value === 'number' ? r.value : Number(r.value);
+  if (!label || !Number.isFinite(value)) return null;
+  return { label, value, tone: coerceTone(r.tone) };
+}
+
+function coerceStackedRow(row: unknown): ChartStackedRow | null {
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const label = typeof r.label === 'string' ? r.label : '';
+  const segsRaw = Array.isArray(r.segments) ? r.segments : [];
+  const segments: ChartStackedRow['segments'] = segsRaw
+    .map((v): ChartStackedRow['segments'][number] | null => {
+      if (!v || typeof v !== 'object') return null;
+      const o = v as Record<string, unknown>;
+      const name = typeof o.name === 'string' ? o.name : '';
+      const value = typeof o.value === 'number' ? o.value : Number(o.value);
+      if (!name || !Number.isFinite(value)) return null;
+      return { name, value, tone: coerceTone(o.tone) };
+    })
+    .filter((x): x is ChartStackedRow['segments'][number] => x !== null);
+  if (!label || segments.length === 0) return null;
+  return {
+    label,
+    unit: typeof r.unit === 'string' ? r.unit : undefined,
+    segments,
+  };
+}
+
+function coerceScatterPoint(row: unknown): ChartScatterPoint | null {
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const x = typeof r.x === 'number' ? r.x : Number(r.x);
+  const y = typeof r.y === 'number' ? r.y : Number(r.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return {
+    x,
+    y,
+    label: typeof r.label === 'string' ? r.label : undefined,
+    tone: coerceTone(r.tone),
+  };
+}
+
+export type { ChartSpec } from './types';

--- a/packages/frontend/src/components/ChatPanel/chat-charts/types.ts
+++ b/packages/frontend/src/components/ChatPanel/chat-charts/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Chart spec - what the agent's `render_chart` tool emits and the chat panel
+ * renders as an inline SVG card. Kept narrow so a single LLM payload covers
+ * every chart type without dragging in a full charting library.
+ */
+
+/** Single bar in an "hbar" chart - value compared against an optional cap.
+ *  `unit` is rendered next to the value so 1800 reads "mg" and 320 reads
+ *  "kcal" without forcing the LLM to bake units into labels. */
+export interface ChartBarRow {
+  label: string;
+  value: number;
+  /** Cap for "value / max" gauges. Omit for raw bars; bar widths then
+   *  normalize against the row with the largest value. */
+  max?: number;
+  unit?: string;
+  /** Visual emphasis. `ok` = neutral, `warn` = amber, `danger` = rose.
+   *  Defaults to `ok` when omitted. */
+  tone?: 'ok' | 'warn' | 'danger';
+}
+
+/** Single row in a "compare" chart - N items lined up side by side for the
+ *  same metric. */
+export interface ChartCompareRow {
+  label: string;
+  unit?: string;
+  values: { name: string; value: number; tone?: 'ok' | 'warn' | 'danger' }[];
+}
+
+/** One point in a "timeline" chart - a value over time. Rows render
+ *  top-to-bottom in the order given; the renderer computes the day gap to the
+ *  next row from the two ISO dates and draws it as a connector. */
+export interface ChartTimelinePoint {
+  /** ISO "YYYY-MM-DD" is required for the renderer to compute the gap;
+   *  non-ISO strings still render but drop the gap connector. */
+  date: string;
+  /** Realized value. null/omitted = an upcoming point not yet realized ->
+   *  rendered as a muted "scheduled" pill with no bar. */
+  value?: number | null;
+  /** Optional short tag rendered next to the value, e.g. "outlier". */
+  tag?: string;
+  tone?: 'ok' | 'warn' | 'danger';
+}
+
+/** One slice of a "donut" chart - a category's share of the whole. */
+export interface ChartDonutSlice {
+  label: string;
+  value: number;
+  tone?: 'ok' | 'warn' | 'danger';
+}
+
+/** One bar of a "stacked" chart - a label whose bar is split into named
+ *  segments stacked on top of each other. */
+export interface ChartStackedRow {
+  label: string;
+  unit?: string;
+  segments: { name: string; value: number; tone?: 'ok' | 'warn' | 'danger' }[];
+}
+
+/** One point of a "scatter" chart - an (x, y) coordinate. */
+export interface ChartScatterPoint {
+  x: number;
+  y: number;
+  label?: string;
+  tone?: 'ok' | 'warn' | 'danger';
+}
+
+export type ChartSpec =
+  | {
+      type: 'hbar';
+      title: string;
+      subtitle?: string;
+      note?: string;
+      series: ChartBarRow[];
+    }
+  | {
+      type: 'compare';
+      title: string;
+      subtitle?: string;
+      note?: string;
+      series: ChartCompareRow[];
+    }
+  | {
+      type: 'timeline';
+      title: string;
+      subtitle?: string;
+      note?: string;
+      /** Unit for the value column. Defaults to blank. */
+      unit?: string;
+      series: ChartTimelinePoint[];
+    }
+  | {
+      type: 'donut';
+      title: string;
+      subtitle?: string;
+      note?: string;
+      /** Unit shown with the center total. */
+      unit?: string;
+      series: ChartDonutSlice[];
+    }
+  | {
+      type: 'stacked';
+      title: string;
+      subtitle?: string;
+      note?: string;
+      series: ChartStackedRow[];
+    }
+  | {
+      type: 'scatter';
+      title: string;
+      subtitle?: string;
+      note?: string;
+      xLabel?: string;
+      yLabel?: string;
+      series: ChartScatterPoint[];
+    };

--- a/packages/frontend/src/components/ChatPanel/index.tsx
+++ b/packages/frontend/src/components/ChatPanel/index.tsx
@@ -43,12 +43,18 @@ export default function ChatPanel({
   onInputChange,
   onSendMessage,
   onStop,
+  models,
+  modelId,
+  reasonings,
+  onModelChange,
+  onReasoningChange,
   onAgentSelect,
   onAgentClick,
   onNewChat,
   onArtifactView,
   onSourceClick,
   loadingSourceKey,
+  onAnswer,
   scrollPositionRef,
   voiceChat,
 }: ChatPanelProps) {
@@ -298,6 +304,28 @@ export default function ChatPanel({
     }
   }, [streamingBlocks.length, sending]);
 
+  // Keep the view pinned to the bottom while content GROWS after a scroll was
+  // already issued - e.g. an inline card (question/chart) mounts and expands
+  // its height once options/bars render, which would otherwise leave the card
+  // clipped below the fold. The scroll container itself is flex-sized (fixed
+  // height), so we watch the message-list content wrapper (chatEndRef's parent)
+  // whose height tracks the messages. Re-attaching on every render keeps the
+  // observer pointed at the current wrapper across conditional renders
+  // (loading / welcome / message list). Respects a deliberate scroll-up.
+  useEffect(() => {
+    const content = chatEndRef.current?.parentElement;
+    const container = scrollContainerRef.current;
+    if (!content || !container) return;
+    const observer = new ResizeObserver(() => {
+      if (userScrolledUpRef.current) return;
+      container.scrollTop = container.scrollHeight;
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+    // Re-attach when the message-list mounts/unmounts (loading/welcome/list)
+    // so the observer always points at the live content wrapper.
+  }, [loadingHistory, messages.length, sending]);
+
   const scrollToBottom = useCallback(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     userScrolledUpRef.current = false;
@@ -338,6 +366,11 @@ export default function ChatPanel({
       onInputChange={onInputChange}
       onSendMessage={onSendMessage}
       onStop={onStop}
+      models={models}
+      modelId={modelId}
+      reasonings={reasonings}
+      onModelChange={onModelChange}
+      onReasoningChange={onReasoningChange}
       onAgentSelect={onAgentSelect}
       onAgentClick={onAgentClick}
       voiceChat={{
@@ -419,6 +452,7 @@ export default function ChatPanel({
             onGraphView={(data) => setGraphSearchData(data)}
             documents={documents}
             chatEndRef={chatEndRef}
+            onAnswer={onAnswer}
           />
         )}
       </div>

--- a/packages/frontend/src/components/ChatPanel/models.ts
+++ b/packages/frontend/src/components/ChatPanel/models.ts
@@ -1,0 +1,50 @@
+import type { LlmModel } from './ModelSelectorPrompt';
+
+/**
+ * Selectable chat models. This list is the built-in fallback used when the
+ * backend catalog (GET /chat/models, backed by SSM) is unavailable. To
+ * add/change a model without redeploying, edit the SSM parameter
+ * `/idp-v2/chat/models` instead - the frontend loads it at runtime.
+ *
+ * The agent passes `model_id` straight through to Bedrock (the runtime IAM role
+ * already allows bedrock:InvokeModel on all models), so a catalog entry only
+ * needs a valid Bedrock model id in `value`. The first entry is the default.
+ *
+ * `metrics` (1-10) drive the preview card's bars; they are illustrative, not
+ * measured. `contextWindow`/prices show in the Context/Cost tooltips.
+ */
+export type ChatModel = LlmModel;
+
+export const CHAT_MODELS: ChatModel[] = [
+  {
+    value: 'global.anthropic.claude-sonnet-5',
+    label: 'Sonnet 5',
+    description: '일상 작업에 최적',
+    contextWindow: '1M tokens',
+    inputPrice: '$3.00 / 1M',
+    outputPrice: '$15.00 / 1M',
+    metrics: { intelligence: 8, speed: 8, context: 10, cost: 7 },
+  },
+  {
+    value: 'global.anthropic.claude-opus-4-8',
+    label: 'Opus 4.8',
+    description: '복잡한 작업에 가장 강력',
+    contextWindow: '1M tokens',
+    inputPrice: '$5.00 / 1M',
+    outputPrice: '$25.00 / 1M',
+    metrics: { intelligence: 10, speed: 5, context: 10, cost: 5 },
+  },
+  {
+    value: 'global.anthropic.claude-sonnet-4-6',
+    label: 'Sonnet 4.6',
+    description: '안정적인 이전 세대 모델',
+    contextWindow: '200K tokens',
+    inputPrice: '$3.00 / 1M',
+    outputPrice: '$15.00 / 1M',
+    metrics: { intelligence: 7, speed: 8, context: 8, cost: 7 },
+    // Sonnet 4.6 has no effort/reasoning control.
+    supportsReasoning: false,
+  },
+];
+
+export const DEFAULT_MODEL_ID = CHAT_MODELS[0].value;

--- a/packages/frontend/src/components/ChatPanel/types.ts
+++ b/packages/frontend/src/components/ChatPanel/types.ts
@@ -8,6 +8,7 @@ import type {
   ChatAttachment,
 } from '../../types/project';
 import type { VoiceChatState, BidiModelType } from '../../hooks/useVoiceChat';
+import type { LlmModel, ReasoningLevel } from './ModelSelectorPrompt';
 
 export interface AttachedFile {
   id: string;
@@ -80,12 +81,19 @@ export interface ChatPanelProps {
   onInputChange: (value: string) => void;
   onSendMessage: (files: AttachedFile[], message?: string) => void;
   onStop?: () => void;
+  models?: readonly LlmModel[];
+  modelId?: string;
+  reasonings?: Record<string, ReasoningLevel>;
+  onModelChange?: (modelValue: string) => void;
+  onReasoningChange?: (reasonings: Record<string, ReasoningLevel>) => void;
   onAgentSelect?: (agentName: string | null) => void;
   onAgentClick: () => void;
   onNewChat: () => void;
   onArtifactView?: (artifactId: string) => void;
   onSourceClick?: (documentId: string, segmentId: string) => void;
   loadingSourceKey?: string | null;
+  /** Post an ask_user answer back as the user's next message. */
+  onAnswer?: (content: string) => void;
   scrollPositionRef?: React.MutableRefObject<number>;
   voiceChat?: VoiceChatProps;
 }

--- a/packages/frontend/src/hooks/useAwsClient.ts
+++ b/packages/frontend/src/hooks/useAwsClient.ts
@@ -351,6 +351,8 @@ export function useAwsClient() {
       agentId?: string,
       runtimeArn?: string,
       signal?: AbortSignal,
+      modelId?: string,
+      reasoning?: string,
     ): Promise<string> => {
       const targetArn = runtimeArn || agentRuntimeArn;
       if (!targetArn) throw new Error('Agent runtime ARN not available');
@@ -373,6 +375,8 @@ export function useAwsClient() {
             project_id: projectId,
             user_id: user.profile?.['cognito:username'] as string,
             agent_id: agentId,
+            ...(modelId ? { model_id: modelId } : {}),
+            ...(reasoning ? { reasoning } : {}),
           }),
           // Aborting closes the HTTP stream, which the agent runtime turns into
           // a cancellation of the in-progress invocation.

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { nanoid } from 'nanoid';
 import {
@@ -19,7 +19,91 @@ import type {
   StreamingBlock,
   AttachedFile,
 } from '../components/ChatPanel/types';
+import type {
+  ReasoningLevel,
+  LlmModel,
+} from '../components/ChatPanel/ModelSelectorPrompt';
+import { DEFAULT_MODEL_ID } from '../components/ChatPanel/models';
 import type { BidiModelType } from './useVoiceChat';
+
+const DEFAULT_REASONING: ReasoningLevel = 'medium';
+
+// Remembers, per session id, the model LAST USED IN THIS BROWSER (localStorage
+// only - NOT synced across browsers/devices, and lost if localStorage is
+// cleared). Reopening a session on the same browser resumes with that model;
+// otherwise the caller falls back to the catalog default. Accurate cross-device
+// restore would require storing model_id in server session metadata (separate
+// work).
+const SESSION_MODEL_KEY = 'idp.sessionModels';
+
+/** Read the whole session->model map, clearing the stored value if it is
+ *  corrupted (invalid JSON) or not a plain object, so a bad value can't cause
+ *  repeated parse failures on every access. */
+function readSessionModelMap(): Record<string, string> {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(SESSION_MODEL_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      localStorage.removeItem(SESSION_MODEL_KEY);
+      return {};
+    }
+    return parsed as Record<string, string>;
+  } catch {
+    // Corrupted JSON (raw was present but unparseable): drop it so subsequent
+    // reads don't keep failing. Guard removeItem itself in case storage throws.
+    if (raw !== null) {
+      try {
+        localStorage.removeItem(SESSION_MODEL_KEY);
+      } catch {
+        // storage unavailable - nothing more we can do
+      }
+    }
+    return {};
+  }
+}
+
+/** The model last used for this session in THIS browser, or null. Non-string
+ *  entries are ignored. */
+function loadSessionModel(sessionId: string): string | null {
+  const value = readSessionModelMap()[sessionId];
+  return typeof value === 'string' ? value : null;
+}
+
+function saveSessionModel(sessionId: string, modelId: string): void {
+  try {
+    const map = readSessionModelMap();
+    if (map[sessionId] === modelId) return;
+    map[sessionId] = modelId;
+    localStorage.setItem(SESSION_MODEL_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage unavailable / quota - non-fatal, model just won't persist.
+  }
+}
+
+function deleteSessionModel(sessionId: string): void {
+  try {
+    const map = readSessionModelMap();
+    if (!(sessionId in map)) return;
+    delete map[sessionId];
+    localStorage.setItem(SESSION_MODEL_KEY, JSON.stringify(map));
+  } catch {
+    // non-fatal
+  }
+}
+
+// Typewriter buffer for streamed answer text. The model streams text in uneven
+// bursts (a big chunk, then a network/model gap, then more), which renders as a
+// stuttering caret if drawn as-is. We buffer incoming text and reveal it at a
+// steady fixed interval so bursts and gaps are absorbed and the caret moves
+// smoothly. Char-based reveal (not word) so it works for Korean/CJK too. Only
+// the on-screen streamingBlocks text is buffered; the final message content
+// (pendingMessagesRef) is accumulated immediately for accuracy.
+const TYPE_TICK_MS = 30; // reveal timer interval (~33 fps)
+const TYPE_DRAIN_MS = 350; // aim to empty the current backlog over this window
+const TYPE_MIN_CPS = 45; // floor chars/sec so a tiny trickle still moves
+const TYPE_MAX_STEP = 24; // cap chars/tick so a huge burst doesn't dump at once
 
 /** Convert streaming blocks to ChatMessage array (fallback when pendingMessagesRef is empty) */
 function blocksToMessages(blocks: StreamingBlock[]): ChatMessage[] {
@@ -59,9 +143,18 @@ function blocksToMessages(blocks: StreamingBlock[]): ChatMessage[] {
 
 interface UseChatSessionOptions {
   projectId: string;
+  models?: readonly LlmModel[];
+  /** True once the catalog API has responded. Restoring a session's remembered
+   *  model waits for this so the initial fallback list can't wrongly drop a
+   *  custom (SSM-only) model. */
+  modelsLoaded?: boolean;
 }
 
-export function useChatSession({ projectId }: UseChatSessionOptions) {
+export function useChatSession({
+  projectId,
+  models,
+  modelsLoaded,
+}: UseChatSessionOptions) {
   const { t } = useTranslation();
   const { fetchApi, invokeAgent } = useAwsClient();
   const { showToast } = useToast();
@@ -88,6 +181,49 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
   const streamingBlocksRef = useRef<StreamingBlock[]>([]);
   // Controls the in-flight agent request so the user can stop generation.
   const abortControllerRef = useRef<AbortController | null>(null);
+  // Typewriter buffer: text received from the stream but not yet revealed, the
+  // amount already shown, and the reveal timer.
+  const typePendingRef = useRef('');
+  const typeShownRef = useRef('');
+  const typeTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Set by handleStreamEvent so stream teardown (end/abort/error) can drain and
+  // stop the typewriter without re-declaring the closure.
+  const flushTypewriterRef = useRef<(() => void) | null>(null);
+
+  // Selected chat model + per-model reasoning level. Sent with each turn and
+  // remembered across turns within a session.
+  const [modelId, setModelId] = useState<string>(DEFAULT_MODEL_ID);
+  const [reasonings, setReasonings] = useState<Record<string, ReasoningLevel>>(
+    {},
+  );
+  // A model remembered for a just-opened session, held until the catalog loads
+  // so we validate against the real catalog (not the initial fallback).
+  const pendingModelRestoreRef = useRef<string | null>(null);
+
+  // Keep stable refs of the catalog for use inside callbacks/effects.
+  const modelsRef = useRef(models);
+  modelsRef.current = models;
+
+  // The catalog default is the first entry (matches models.ts DEFAULT_MODEL_ID
+  // ordering); fall back to the built-in constant if the catalog is empty.
+  const catalogDefaultId = models?.[0]?.value ?? DEFAULT_MODEL_ID;
+  const isModelInCatalog = useCallback(
+    (id: string) => !!modelsRef.current?.some((m) => m.value === id),
+    [],
+  );
+
+  // Deferred validation: if a session was opened before the catalog loaded, we
+  // stashed its remembered model; once loaded, drop it to the catalog default
+  // if it's no longer offered (removed, or a model from another browser).
+  useEffect(() => {
+    if (!modelsLoaded) return;
+    const pending = pendingModelRestoreRef.current;
+    if (pending === null) return;
+    pendingModelRestoreRef.current = null;
+    if (!isModelInCatalog(pending)) {
+      setModelId(catalogDefaultId);
+    }
+  }, [modelsLoaded, catalogDefaultId, isModelInCatalog]);
 
   const loadSessions = useCallback(async () => {
     try {
@@ -125,11 +261,18 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
 
   useWebSocketMessage('sessions', handleSessionMessage);
 
-  const handleNewSession = useCallback(() => {
+  const handleNewSession = useCallback((persistModelId?: string) => {
     const newSessionId = nanoid(33);
     setCurrentSessionId(newSessionId);
     setMessages([]);
+    // Remember the chosen model against the new session id immediately (used
+    // when a model change starts a fresh chat), so it's restored even before
+    // the first message is sent.
+    if (persistModelId) {
+      saveSessionModel(newSessionId, persistModelId);
+    }
     // Voice chat and agent reset are handled by the parent
+    return newSessionId;
   }, []);
 
   const loadMoreSessions = useCallback(async () => {
@@ -174,6 +317,27 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
       setCurrentSessionId(sessionId);
       setMessages([]);
       setLoadingHistory(true);
+
+      // Restore the model last used for this session IN THIS BROWSER. Validate
+      // against the current catalog: a remembered model that's no longer in the
+      // catalog (removed, or another browser) falls back to the catalog default.
+      // If the catalog hasn't loaded yet, stash the candidate and let the
+      // deferred effect validate it once loaded (so the initial fallback list
+      // can't wrongly drop a custom SSM-only model).
+      const remembered = loadSessionModel(sessionId);
+      if (!remembered) {
+        pendingModelRestoreRef.current = null;
+        setModelId(catalogDefaultId);
+      } else if (modelsLoaded) {
+        pendingModelRestoreRef.current = null;
+        setModelId(
+          isModelInCatalog(remembered) ? remembered : catalogDefaultId,
+        );
+      } else {
+        // Defer validation until the catalog loads.
+        pendingModelRestoreRef.current = remembered;
+        setModelId(remembered);
+      }
 
       const session = sessions.find((s) => s.session_id === sessionId);
 
@@ -522,7 +686,16 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
         setLoadingHistory(false);
       }
     },
-    [fetchApi, projectId, showToast, t, sessions],
+    [
+      fetchApi,
+      projectId,
+      showToast,
+      t,
+      sessions,
+      catalogDefaultId,
+      modelsLoaded,
+      isModelInCatalog,
+    ],
   );
 
   const handleSessionRename = useCallback(
@@ -553,6 +726,8 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
       await fetchApi(`chat/projects/${projectId}/sessions/${sessionId}`, {
         method: 'DELETE',
       });
+      // Drop this session's remembered model from localStorage too.
+      deleteSessionModel(sessionId);
       setSessions((prev) => prev.filter((s) => s.session_id !== sessionId));
       if (sessionId === currentSessionId) {
         opts.voiceChatDisconnect();
@@ -578,23 +753,97 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
       });
     };
 
+    // Write the currently-revealed text into the active (last) streaming text
+    // block. Called by the reveal timer as it advances typeShownRef.
+    const paintTypewriter = () => {
+      const shown = typeShownRef.current;
+      updateBlocks((prev) => {
+        const last = prev[prev.length - 1];
+        if (last?.type === 'text') {
+          if (last.content === shown) return prev;
+          return [...prev.slice(0, -1), { type: 'text', content: shown }];
+        }
+        return [...prev, { type: 'text', content: shown }];
+      });
+    };
+
+    const stopTypeTimer = () => {
+      if (typeTimerRef.current !== null) {
+        clearInterval(typeTimerRef.current);
+        typeTimerRef.current = null;
+      }
+    };
+
+    // Fixed-interval reveal: each tick advances by a near-constant amount
+    // (scaled just enough to keep a large backlog from lagging), so bursts and
+    // network gaps are absorbed and the caret moves steadily.
+    const typeTick = () => {
+      const backlog =
+        typePendingRef.current.length - typeShownRef.current.length;
+      if (backlog > 0) {
+        const perTick = Math.min(
+          TYPE_MAX_STEP,
+          Math.max(
+            Math.ceil((TYPE_MIN_CPS * TYPE_TICK_MS) / 1000),
+            Math.ceil((backlog * TYPE_TICK_MS) / TYPE_DRAIN_MS),
+          ),
+        );
+        typeShownRef.current = typePendingRef.current.slice(
+          0,
+          typeShownRef.current.length + perTick,
+        );
+        paintTypewriter();
+      } else {
+        stopTypeTimer();
+      }
+    };
+
+    // Reveal all buffered text at once and stop the timer. Called before any
+    // non-text event (to preserve order) and at stream end.
+    const flushTypewriter = () => {
+      stopTypeTimer();
+      if (typePendingRef.current !== typeShownRef.current) {
+        typeShownRef.current = typePendingRef.current;
+        paintTypewriter();
+      }
+    };
+    // Expose flush so stream teardown (end/abort) can drain the buffer.
+    flushTypewriterRef.current = flushTypewriter;
+
+    // Any non-text event must appear after all text received so far. Drain the
+    // typewriter buffer into the active text block, then reset it so the next
+    // text run types from empty.
+    if (event.type !== 'text') {
+      flushTypewriter();
+      typePendingRef.current = '';
+      typeShownRef.current = '';
+    }
+
     switch (event.type) {
       case 'text':
         if (event.content && typeof event.content === 'string') {
           const text = event.content;
           const forceNew = forceNewTextBlockRef.current;
           forceNewTextBlockRef.current = false;
-          updateBlocks((prev) => {
-            const last = prev[prev.length - 1];
-            if (last?.type === 'text' && !forceNew) {
-              return [
-                ...prev.slice(0, -1),
-                { type: 'text', content: last.content + text },
-              ];
-            }
-            return [...prev, { type: 'text', content: text }];
-          });
-          // Also accumulate in pending messages to preserve order
+
+          // A forced break (after a tool block) starts a fresh text block:
+          // flush the previous buffer into it, then reset the typewriter so the
+          // new block types from empty.
+          if (forceNew) {
+            flushTypewriter();
+            typePendingRef.current = '';
+            typeShownRef.current = '';
+            updateBlocks((prev) => [...prev, { type: 'text', content: '' }]);
+          }
+
+          // Buffer the on-screen text and let the timer reveal it steadily.
+          typePendingRef.current += text;
+          if (typeTimerRef.current === null) {
+            typeTimerRef.current = setInterval(typeTick, TYPE_TICK_MS);
+          }
+
+          // Accumulate the final message content immediately (not buffered), so
+          // the persisted/committed answer is always complete and correct.
           const pending = pendingMessagesRef.current;
           const lastPending = pending[pending.length - 1];
           if (
@@ -881,6 +1130,13 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
       toolUseMapRef.current.clear();
       toolInputMapRef.current.clear();
       forceNewTextBlockRef.current = false;
+      // Reset the typewriter buffer for the new turn.
+      if (typeTimerRef.current !== null) {
+        clearInterval(typeTimerRef.current);
+        typeTimerRef.current = null;
+      }
+      typePendingRef.current = '';
+      typeShownRef.current = '';
 
       try {
         const contentBlocks: ContentBlock[] = [];
@@ -940,6 +1196,18 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
         const abortController = new AbortController();
         abortControllerRef.current = abortController;
 
+        // Remember the model used for this session so reopening it later resumes
+        // with the same model.
+        saveSessionModel(currentSessionId, modelId);
+
+        // Only send a reasoning level for models that support it; models like
+        // Sonnet 4.6 have no effort control, so we omit reasoning entirely.
+        const selectedModel = models?.find((m) => m.value === modelId);
+        const reasoningToSend =
+          selectedModel?.supportsReasoning === false
+            ? undefined
+            : (reasonings[modelId] ?? DEFAULT_REASONING);
+
         await invokeAgent(
           contentBlocks,
           currentSessionId,
@@ -948,7 +1216,13 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
           selectedAgent?.agent_id,
           undefined,
           abortController.signal,
+          modelId,
+          reasoningToSend,
         );
+
+        // Stream ended: drain any text still in the typewriter buffer so the
+        // final frame is complete before we tear down streaming state.
+        flushTypewriterRef.current?.();
 
         // pending has all messages in order (text + tool_result + stage)
         let pending = pendingMessagesRef.current;
@@ -961,6 +1235,9 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
 
         setMessages((prev) => [...prev, ...pending]);
       } catch (error) {
+        // Stop the typewriter (abort/error): reveal whatever was buffered.
+        flushTypewriterRef.current?.();
+
         // Preserve any content accumulated before the error/stop
         let partial = pendingMessagesRef.current;
         pendingMessagesRef.current = [];
@@ -999,6 +1276,9 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
       projectId,
       handleStreamEvent,
       loadSessions,
+      modelId,
+      reasonings,
+      models,
     ],
   );
 
@@ -1007,6 +1287,16 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
   // kept (handled in handleSendMessage's catch).
   const stopStreaming = useCallback(() => {
     abortControllerRef.current?.abort();
+  }, []);
+
+  // Clear the typewriter reveal timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (typeTimerRef.current !== null) {
+        clearInterval(typeTimerRef.current);
+        typeTimerRef.current = null;
+      }
+    };
   }, []);
 
   return {
@@ -1036,5 +1326,9 @@ export function useChatSession({ projectId }: UseChatSessionOptions) {
     handleStreamEvent,
     handleSendMessage,
     stopStreaming,
+    modelId,
+    setModelId,
+    reasonings,
+    setReasonings,
   };
 }

--- a/packages/frontend/src/hooks/useDocuments.ts
+++ b/packages/frontend/src/hooks/useDocuments.ts
@@ -60,6 +60,9 @@ export function useDocuments({
   const [workflowProgressMap, setWorkflowProgressMap] = useState<
     Record<string, WorkflowProgress>
   >({});
+  // Mirror of workflowProgressMap for reading the current tracked docs outside
+  // a state updater (kept in sync via the effect below).
+  const workflowProgressMapRef = useRef<Record<string, WorkflowProgress>>({});
   const [uploading, setUploading] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<Document | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -84,6 +87,12 @@ export function useDocuments({
     }, delayMs);
     deferredTimersRef.current.add(id);
   }, []);
+
+  // Keep the ref in sync so async callbacks can read the current tracked docs
+  // without doing side effects inside a state updater.
+  useEffect(() => {
+    workflowProgressMapRef.current = workflowProgressMap;
+  }, [workflowProgressMap]);
 
   const loadDocuments = useCallback(async () => {
     try {
@@ -153,10 +162,38 @@ export function useDocuments({
             }
           >;
         }[]
-      >(`projects/${projectId}/documents/progress`);
+      >(`projects/${projectId}/documents/progress?active_only=true`);
+
+      // Server returns ONLY active (non-terminal) workflows here. Build the map
+      // from them, and drop any previously-tracked doc that is now absent -
+      // absence means the workflow reached a terminal state (even if we missed
+      // the WebSocket completion event), so it should stop showing as in
+      // progress. Dropped docs get a doc/workflow refresh to reflect the final
+      // status. qa_regen entries are kept even if absent (post-completion work).
+      const activeIds = new Set(progressData.map((p) => p.document_id));
+
+      // Detect vanished (now-terminal) tracked docs from the ref, OUTSIDE the
+      // state updater, so the updater stays pure (updaters may be deferred or
+      // re-run in Strict Mode; side effects there are unreliable).
+      const prevMap = workflowProgressMapRef.current;
+      const vanished = Object.entries(prevMap)
+        .filter(
+          ([docId, entry]) =>
+            !activeIds.has(docId) && entry.qaRegen?.status !== 'in_progress',
+        )
+        .map(([docId]) => docId);
 
       setWorkflowProgressMap((prev) => {
-        const newMap = { ...prev };
+        const newMap: Record<string, WorkflowProgress> = {};
+
+        // Carry over entries that are still active or have qa_regen running.
+        for (const [docId, entry] of Object.entries(prev)) {
+          if (activeIds.has(docId)) continue; // rebuilt below from fresh data
+          if (entry.qaRegen?.status === 'in_progress') {
+            newMap[docId] = entry;
+          }
+        }
+
         for (const progress of progressData) {
           const doc = documents.find(
             (d) => d.document_id === progress.document_id,
@@ -201,6 +238,13 @@ export function useDocuments({
         }
         return newMap;
       });
+
+      // A tracked workflow that dropped out of the active list finished while we
+      // weren't looking - refresh docs/workflows so its terminal status shows.
+      if (vanished.length > 0) {
+        loadDocumentsRef.current();
+        loadWorkflowsRef.current();
+      }
     } catch (error) {
       console.error('Failed to fetch document progress:', error);
     }

--- a/packages/frontend/src/hooks/useModelCatalog.ts
+++ b/packages/frontend/src/hooks/useModelCatalog.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { useAwsClient } from './useAwsClient';
+import { CHAT_MODELS, type ChatModel } from '../components/ChatPanel/models';
+
+/**
+ * Loads the chat model catalog from the backend (GET /chat/models, backed by
+ * the SSM parameter /idp-v2/chat/models). Falls back to the built-in
+ * CHAT_MODELS list while loading or if the request fails, so the selector
+ * always has something to show. Adding/removing a model is done by editing the
+ * SSM parameter - no redeploy needed.
+ */
+export interface ModelCatalog {
+  models: ChatModel[];
+  /** True once the API responded (success or failure). Until then `models` is
+   *  the built-in fallback, so callers should defer catalog-dependent
+   *  validation (e.g. dropping a session's remembered model) until loaded. */
+  loaded: boolean;
+}
+
+export function useModelCatalog(): ModelCatalog {
+  const { fetchApi } = useAwsClient();
+  const [models, setModels] = useState<ChatModel[]>(CHAT_MODELS);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchApi<{ models: ChatModel[] }>('chat/models');
+        if (!cancelled && data?.models?.length) {
+          setModels(data.models);
+        }
+      } catch {
+        // Keep the built-in fallback list.
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchApi]);
+
+  return { models, loaded };
+}

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -460,7 +460,39 @@
     "graphSourcesFound": "{{count}} additional pages discovered",
     "graphNoAdditionalSources": "No additional pages discovered",
     "viewGraph": "View graph",
-    "stop": "Stop"
+    "stop": "Stop",
+    "model": {
+      "select": "Select model",
+      "searchPlaceholder": "Search models...",
+      "notFound": "No models found",
+      "reasoning": "Reasoning",
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High",
+      "intelligence": "Intelligence",
+      "speed": "Speed",
+      "context": "Context",
+      "cost": "Cost",
+      "contextWindow": "{{value}} context window",
+      "priceInfo": "{{input}} input · {{output}} output",
+      "changeTitle": "Change model",
+      "changeConfirm": "Changing the model starts a new conversation. Continue?"
+    },
+    "chart": {
+      "scheduled": "Scheduled",
+      "dayGap": "{{count}}d gap"
+    },
+    "question": {
+      "header": "Please choose",
+      "confirm": "Confirm",
+      "next": "Next",
+      "skip": "Skip",
+      "skipped": "skipped",
+      "answered": "answered",
+      "answeredHint": "This question was answered.",
+      "customPlaceholder": "Other...",
+      "textPlaceholder": "Type your answer..."
+    }
   },
   "viewer": {
     "zoomIn": "Zoom In",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -460,7 +460,39 @@
     "graphSourcesFound": "追加発見ページ {{count}}件",
     "graphNoAdditionalSources": "追加発見ページなし",
     "viewGraph": "グラフを見る",
-    "stop": "停止"
+    "stop": "停止",
+    "model": {
+      "select": "モデルを選択",
+      "searchPlaceholder": "モデルを検索...",
+      "notFound": "モデルが見つかりません",
+      "reasoning": "推論",
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "intelligence": "知能",
+      "speed": "速度",
+      "context": "コンテキスト",
+      "cost": "コスト",
+      "contextWindow": "コンテキスト {{value}}",
+      "priceInfo": "入力 {{input}} · 出力 {{output}}",
+      "changeTitle": "モデルを変更",
+      "changeConfirm": "モデルを変更すると新しい会話が始まります。続行しますか?"
+    },
+    "chart": {
+      "scheduled": "予定",
+      "dayGap": "{{count}}日間隔"
+    },
+    "question": {
+      "header": "選択してください",
+      "confirm": "確認",
+      "next": "次へ",
+      "skip": "スキップ",
+      "skipped": "スキップ",
+      "answered": "回答済み",
+      "answeredHint": "この質問は回答済みです。",
+      "customPlaceholder": "その他...",
+      "textPlaceholder": "回答を入力してください..."
+    }
   },
   "viewer": {
     "zoomIn": "拡大",

--- a/packages/frontend/src/i18n/locales/ko.json
+++ b/packages/frontend/src/i18n/locales/ko.json
@@ -460,7 +460,39 @@
     "graphSourcesFound": "추가 발견된 페이지 {{count}}건",
     "graphNoAdditionalSources": "추가 발견된 페이지 없음",
     "viewGraph": "그래프 보기",
-    "stop": "중지"
+    "stop": "중지",
+    "model": {
+      "select": "모델 선택",
+      "searchPlaceholder": "모델 검색...",
+      "notFound": "모델을 찾을 수 없습니다",
+      "reasoning": "추론",
+      "low": "낮음",
+      "medium": "보통",
+      "high": "높음",
+      "intelligence": "지능",
+      "speed": "속도",
+      "context": "컨텍스트",
+      "cost": "비용",
+      "contextWindow": "컨텍스트 {{value}}",
+      "priceInfo": "입력 {{input}} · 출력 {{output}}",
+      "changeTitle": "모델 변경",
+      "changeConfirm": "모델을 변경하면 새 대화가 시작됩니다. 계속할까요?"
+    },
+    "chart": {
+      "scheduled": "예정",
+      "dayGap": "{{count}}일 간격"
+    },
+    "question": {
+      "header": "선택해 주세요",
+      "confirm": "확인",
+      "next": "다음",
+      "skip": "건너뛰기",
+      "skipped": "건너뜀",
+      "answered": "응답함",
+      "answeredHint": "이 질문은 응답했습니다.",
+      "customPlaceholder": "기타...",
+      "textPlaceholder": "답변을 입력하세요..."
+    }
   },
   "viewer": {
     "zoomIn": "확대",

--- a/packages/frontend/src/routes/projects/$projectId.tsx
+++ b/packages/frontend/src/routes/projects/$projectId.tsx
@@ -34,6 +34,7 @@ import { useProjectData } from '../../hooks/useProjectData';
 import { usePanelLayout } from '../../hooks/usePanelLayout';
 import { useSystemPrompts } from '../../hooks/useSystemPrompts';
 import { useChatSession } from '../../hooks/useChatSession';
+import { useModelCatalog } from '../../hooks/useModelCatalog';
 import { useVoiceChatManager } from '../../hooks/useVoiceChatManager';
 import { useAgents } from '../../hooks/useAgents';
 import { useArtifacts } from '../../hooks/useArtifacts';
@@ -57,8 +58,12 @@ function ProjectDetailPage() {
   const panelLayout = usePanelLayout();
   const { systemPromptTabs } = useSystemPrompts({ fetchApi });
 
+  // Chat model catalog (SSM-backed, runtime-loaded so models can be added
+  // without redeploying).
+  const { models, loaded: modelsLoaded } = useModelCatalog();
+
   // 2. Chat session (provides handleNewSession, setMessages, setStreamingBlocks)
-  const chatSession = useChatSession({ projectId });
+  const chatSession = useChatSession({ projectId, models, modelsLoaded });
 
   // 3. Voice chat manager (needs setMessages, setStreamingBlocks)
   const [selectedVoiceModel, setSelectedVoiceModel] = useState<BidiModelType>(
@@ -178,14 +183,45 @@ function ProjectDetailPage() {
 
   // --- Wrapped callbacks for ChatPanel/Sidebar compatibility ---
 
-  // handleNewSession that also resets voice/agent state
-  const handleNewSession = useCallback(() => {
-    chatSession.handleNewSession();
-    agentsHook.setSelectedAgent(null);
-    voiceChatManager.setVoiceChatMode(false);
-    voiceChatManager.voiceChatDisconnectRef.current();
+  // handleNewSession that also resets voice/agent state. `persistModelId`
+  // remembers the chosen model against the new session id immediately (used
+  // when a model change starts a fresh chat).
+  const handleNewSession = useCallback(
+    (persistModelId?: string) => {
+      chatSession.handleNewSession(persistModelId);
+      agentsHook.setSelectedAgent(null);
+      voiceChatManager.setVoiceChatMode(false);
+      voiceChatManager.voiceChatDisconnectRef.current();
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatSession.handleNewSession]);
+    [chatSession.handleNewSession],
+  );
+
+  // --- Model selection ---
+  // Changing the model mid-conversation would mix responses from different
+  // models in one session, so we confirm and start a fresh chat.
+  const [pendingModelChange, setPendingModelChange] = useState<string | null>(
+    null,
+  );
+  const handleModelChange = useCallback(
+    (modelValue: string) => {
+      if (modelValue === chatSession.modelId) return;
+      if (chatSession.messages.length > 0 || chatSession.sending) {
+        setPendingModelChange(modelValue);
+      } else {
+        chatSession.setModelId(modelValue);
+      }
+    },
+    [chatSession],
+  );
+  const confirmModelChange = useCallback(() => {
+    if (pendingModelChange) {
+      chatSession.setModelId(pendingModelChange);
+      // Start a fresh chat and remember the model for the new session id.
+      handleNewSession(pendingModelChange);
+    }
+    setPendingModelChange(null);
+  }, [pendingModelChange, chatSession, handleNewSession]);
 
   // handleSessionSelect with agent/voice context
   const handleSessionSelect = useCallback(
@@ -219,6 +255,17 @@ function ProjectDetailPage() {
   const handleSendMessage = useCallback(
     (files: AttachedFile[], message?: string) => {
       chatSession.handleSendMessage(files, message, agentsHook.selectedAgent);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chatSession.handleSendMessage, agentsHook.selectedAgent],
+  );
+
+  // ask_user answer: post the user's selection back as their next message so
+  // the agent reads it on the following turn.
+  const handleAnswer = useCallback(
+    (content: string) => {
+      if (!content.trim()) return;
+      chatSession.handleSendMessage([], content, agentsHook.selectedAgent);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [chatSession.handleSendMessage, agentsHook.selectedAgent],
@@ -353,12 +400,18 @@ function ProjectDetailPage() {
                 onInputChange={chatSession.setInputMessage}
                 onSendMessage={handleSendMessage}
                 onStop={chatSession.stopStreaming}
+                models={models}
+                modelId={chatSession.modelId}
+                reasonings={chatSession.reasonings}
+                onModelChange={handleModelChange}
+                onReasoningChange={chatSession.setReasonings}
                 onAgentSelect={agentsHook.handleAgentSelect}
                 onAgentClick={() => agentsHook.setShowAgentModal(true)}
                 onNewChat={handleNewSession}
                 onArtifactView={artifactsHook.handleArtifactSelect}
                 onSourceClick={documentsHook.handleSourceClick}
                 loadingSourceKey={documentsHook.loadingSourceKey}
+                onAnswer={handleAnswer}
                 scrollPositionRef={chatSession.chatScrollPositionRef}
                 voiceChat={{
                   available: !!bidiAgentRuntimeArn,
@@ -525,6 +578,20 @@ function ProjectDetailPage() {
         confirmText={t('common.delete')}
         variant="danger"
         loading={documentsHook.deleting}
+      />
+
+      {/* Model Change Confirmation Modal (starts a new chat) */}
+      <ConfirmModal
+        isOpen={!!pendingModelChange}
+        onClose={() => setPendingModelChange(null)}
+        onConfirm={confirmModelChange}
+        title={t('chat.model.changeTitle', 'Change model')}
+        message={t(
+          'chat.model.changeConfirm',
+          'Changing the model starts a new conversation. Continue?',
+        )}
+        confirmText={t('agent.startNewChat', 'Start new chat')}
+        variant="warning"
       />
 
       {/* Agent Select Modal */}

--- a/packages/infra/src/functions/step-functions/dataset-process/index.py
+++ b/packages/infra/src/functions/step-functions/dataset-process/index.py
@@ -136,6 +136,30 @@ def _snake_case_columns(df: "pd.DataFrame") -> "pd.DataFrame":
     return df
 
 
+def _normalize_mixed_columns(df: "pd.DataFrame") -> "pd.DataFrame":
+    """Coerce mixed-type object columns to string so Parquet conversion succeeds.
+
+    Excel/CSV columns frequently mix types in one column (e.g. Titanic's 'Ticket'
+    holds both "A/5 21171" and 349909). pandas keeps these as an object column,
+    but pyarrow infers the Arrow type from the first value and then raises
+    ArrowTypeError ("Expected bytes, got a 'int' object") on the first value of a
+    different type. We only touch object columns that actually contain more than
+    one Python type among non-null values, casting them to string. Clean
+    single-type columns (numeric, all-string) are left untouched so their Parquet
+    types stay correct for SQL. NaN is preserved (not turned into the text 'nan').
+    """
+    import pandas as pd
+
+    for col in df.columns:
+        if df[col].dtype != object:
+            continue
+        non_null = df[col].dropna()
+        types = {type(v) for v in non_null}
+        if len(types) > 1:
+            df[col] = df[col].map(lambda v: v if pd.isna(v) else str(v))
+    return df
+
+
 def _output_dir(document_key: str) -> str:
     """Directory to write parquet/reference into: a `dataset/` subfolder under the
     original document's folder.
@@ -212,6 +236,9 @@ def handler(event: dict, context) -> dict:
         # after validation, so both the Parquet and the reference doc/DDB use
         # the same normalized names.
         df = _snake_case_columns(sheet["df"])
+        # Coerce mixed-type columns to string so Parquet conversion can't fail on
+        # a column that holds e.g. both ints and strings (common in spreadsheets).
+        df = _normalize_mixed_columns(df)
 
         # parquet -> S3
         buf = io.BytesIO()
@@ -365,15 +392,16 @@ def _load_and_validate(
 def _validate_dataframe(df: pd.DataFrame) -> list[str]:
     """Lightweight validation for CSV (openpyxl checks cover Excel).
 
-    Duplicate column names are not rejected: snake_case normalization makes them
-    unique automatically (see _snake_case_columns).
+    Neither duplicate nor unnamed/empty header columns are rejected: snake_case
+    normalization gives every column a unique, valid identifier automatically
+    (see _snake_case_columns; pandas 'Unnamed: 0' -> unnamed_0, a blank header ->
+    col/col_1). Rejecting them would fail common exports (e.g. a leading index
+    column from df.to_csv()) that are otherwise perfectly tabular. No column is
+    dropped, so no data is lost.
     """
     reasons = []
     if df.empty:
         reasons.append("데이터 행이 없습니다.")
-    cols = [str(c) for c in df.columns]
-    if any(c.startswith("Unnamed:") or c.strip() == "" for c in cols):
-        reasons.append("빈 헤더 열이 있습니다.")
     return reasons
 
 

--- a/packages/infra/src/functions/step-functions/dataset-process/validator.py
+++ b/packages/infra/src/functions/step-functions/dataset-process/validator.py
@@ -38,17 +38,15 @@ def validate_workbook(wb) -> list[SheetValidation]:
         if merged is not None and getattr(merged, "ranges", None):
             reasons.append("병합된 셀이 있어 표 구조가 깨집니다.")
 
-        # Header (first row) checks: needs a non-empty header row. Duplicate
-        # column names are NOT rejected: the parquet step normalizes columns to
-        # unique snake_case (e.g. material, material_1), so duplicates are handled
-        # automatically rather than being a user-fix case.
+        # Header (first row) check: only reject when the ENTIRE header row is
+        # empty (no columns at all). Individual empty/duplicate header cells are
+        # NOT rejected: the parquet step normalizes every column to a unique
+        # snake_case identifier (blank -> col/col_1, duplicates -> material,
+        # material_1), so a leading index column or a stray blank column no longer
+        # fails an otherwise-tabular sheet. No column is dropped.
         header = _first_row_values(ws)
-        if not header:
+        if not header or all(v is None or str(v).strip() == "" for v in header):
             reasons.append("헤더(첫 행)가 비어 있습니다.")
-        else:
-            empty = [i for i, v in enumerate(header) if v is None or str(v).strip() == ""]
-            if empty:
-                reasons.append("빈 헤더 열이 있습니다.")
 
         # Needs at least one data row beyond the header.
         if ws.max_row is not None and ws.max_row < 2:

--- a/packages/infra/src/prompts/chat/system_prompt.txt
+++ b/packages/infra/src/prompts/chat/system_prompt.txt
@@ -84,8 +84,29 @@ When a question needs BOTH (e.g. "the gaming OLED TV — tell me its price and s
 - For comparisons or tabular data, use markdown tables.
 - Keep responses focused and relevant. Avoid unnecessary preamble.
 
+### Visualizing numbers (render_chart)
+- When an answer centers on numeric data you just fetched — a metric per item,
+  item-vs-item comparison, or a value over time — call `render_chart` to show it
+  inline as a chart card, in addition to a short prose summary.
+- Chart types: "hbar" (a quantity per label), "compare" (side-by-side bars
+  across named items per label), "timeline" (a value over dated points),
+  "donut" (composition / share of a whole), "stacked" (vertical bars split into
+  named segments, part-to-whole across categories), "scatter" (correlation
+  between two numeric variables). Pick the shape that fits the question.
+- Every `value` MUST come from a previous tool result in the same turn. Never
+  invent numbers to fill a chart. If you have no real numbers, don't chart.
+- Keep the prose answer too; the chart complements it, not replaces it.
+
+### Asking the user to choose (ask_user)
+- When a decision is the user's to make and you must not guess (ambiguous
+  choice, missing required parameter, confirmation before an expensive or
+  irreversible action), call `ask_user` with structured options instead of
+  guessing or writing "reply with A or B" in prose.
+- The user's selection arrives as their next message; read it and act on it.
+
 ### Handling Ambiguity
 - If the user's question is ambiguous, ask a clarifying question before searching.
+  Prefer `ask_user` with concrete options when the ambiguity is a discrete choice.
 - If multiple interpretations are possible, address the most likely one and mention alternatives.
 
 ### Multi-turn Conversations

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@aws/nx-plugin':
         specifier: 0.90.1
         version: 0.90.1(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/babel__core@7.20.5)(@types/node@22.19.1)(@vitest/ui@4.1.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.28.1)(eslint@9.39.4(jiti@2.4.2))(jiti@2.4.2)(jsdom@29.1.1)(lightningcss@1.30.2)(node-fetch@2.7.0(encoding@0.1.13))(nx@22.6.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(postcss@8.5.15)(prettier@3.8.1)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@fortune-sheet/react':
         specifier: ^1.0.4
         version: 1.0.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1650,6 +1653,33 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
@@ -2457,11 +2487,26 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@formulajs/formulajs@2.9.3':
     resolution: {integrity: sha512-WpgiuJaBl/Hcda9Ti8a7mlnw/vUZkJrtjABvojz6P6mo6d8EscudyA7iAt/kTLsgi0c8zfmzQd/Yjb4ASFkw+g==}
@@ -9488,6 +9533,9 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
@@ -13080,6 +13128,29 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@base-ui/react@1.6.0(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@borewit/text-codec@0.2.2': {}
@@ -13627,12 +13698,29 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
   '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@formulajs/formulajs@2.9.3':
     dependencies:
@@ -22830,6 +22918,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-alpn@1.2.1: {}
 


### PR DESCRIPTION
  - Add per-project model selector (Sonnet 5 / Opus 4.8 / Sonnet 4.6) with reasoning control
  - Load model catalog from SSM at runtime (GET /chat/models) with Pydantic validation and built-in fallback
  - Validate requested model_id against catalog allowlist in the agent; gate reasoning/effort on the resolved model
  - Prompt to start a new chat on model change; remember per-session model in localStorage (this-browser only)
  - Render render_chart tool results as inline SVG cards (hbar, compare, timeline, donut, stacked, scatter)
  - Render ask_user tool results as inline question cards; post the answer back as the next message
  - Add typewriter buffering to smooth bursty streamed text; keep view pinned to bottom as cards expand
  - Fix dataset validation: accept unnamed/index columns, coerce mixed-type columns for Parquet
  - Fix progress polling: include pending workflows, active-only query, pure state updater
  - Add chat cancellation stop button and thread model/reasoning through invokeAgent