### PR TITLE
docs: update agent, features, and preprocessing for chat and dataset …

### DIFF
--- a/docs/src/content/docs/en/agent-idp.md
+++ b/docs/src/content/docs/en/agent-idp.md
@@ -14,12 +14,21 @@ User question
 AgentCore Runtime (HTTP streaming)
   │
   ▼
-Strands Agent (Claude Opus 4.6)
+Strands Agent (Claude Opus 4.8, default)
   ├─ 1. Understand intent
   ├─ 2. Create execution plan
   ├─ 3. Load skill → call tools → collect results
   └─ 4. Generate final response with citations
 ```
+
+### Model Selection
+
+Users can pick the model and reasoning effort per turn from the chat composer.
+
+- The selectable models are loaded at runtime from a catalog defined in an SSM parameter (`/idp-v2/chat/models`). Adding/removing a model is done by editing the parameter — no redeploy needed.
+- The agent validates the requested `model_id` against the catalog allowlist (the frontend selector is not a security boundary). A model that is not allowed falls back to the default.
+- The reasoning effort (low/medium/high) is passed as `output_config.effort` only when the resolved model supports it.
+- Changing the model starts a new conversation, so responses from different models don't mix within one session.
 
 ---
 
@@ -29,7 +38,8 @@ The agent operates in **skill** units. Skills are markdown files defined in `.sk
 
 | Skill | Purpose | Tools Used |
 |---|---|---|
-| **search** | Document search + web search strategy | Search MCP (summarize, graph_traverse, graph_keyword), DuckDuckGo |
+| **search** | Document search + web search strategy | Search MCP (summarize, graph_traverse, graph_keyword), AgentCore Web Search |
+| **dataset** | Structured data (Excel/CSV) Text2SQL querying | Data MCP (search_datasets, describe_dataset, run_sql) |
 | **docx** | Word document creation/editing | Code Interpreter (python-docx) |
 | **xlsx** | Excel spreadsheet creation/editing | Code Interpreter (openpyxl) |
 | **pptx** | PowerPoint creation/editing | Code Interpreter (python-pptx) |
@@ -79,6 +89,16 @@ MCP tools accessed through the AgentCore Gateway.
 | `create_document` | Create PDF/DOCX/PPTX |
 | `edit_document` | Edit existing documents |
 
+### Data MCP (Structured Data Text2SQL)
+
+Queries Parquet datasets converted from Excel/CSV using SQL. Used for structured data that needs exact aggregation, filtering, or sorting.
+
+| Tool | Description |
+|---|---|
+| `search_datasets` | Hybrid search over the project's datasets by name/description |
+| `describe_dataset` | Retrieve a dataset's schema, samples, and query examples (reference doc) |
+| `run_sql` | Run read-only SQL against a Parquet dataset via DuckDB |
+
 ### Other MCPs
 
 | MCP | Tool | Description |
@@ -89,6 +109,21 @@ MCP tools accessed through the AgentCore Gateway.
 | MD MCP | `load_markdown` | Load markdown |
 | MD MCP | `save_markdown` | Save markdown |
 | MD MCP | `edit_markdown` | Edit markdown |
+
+---
+
+## Local Tools
+
+Tools that run directly in the agent process, not through the Gateway.
+
+| Tool | Description |
+|---|---|
+| `render_chart` | Render an inline chart card in the reply (hbar / compare / timeline / donut / stacked / scatter). Uses only real values from a prior tool result |
+| `ask_user` | Show a structured question card (single / multi / free-text). The user's choice is posted back as the next message and picked up on the following turn |
+| `generate_image` | AI image generation |
+| `code_interpreter` | Isolated Python sandbox execution (see below) |
+
+Results from `render_chart` and `ask_user` are rendered by the frontend as dedicated UI cards instead of plain text.
 
 ---
 

--- a/docs/src/content/docs/en/agent-voice.md
+++ b/docs/src/content/docs/en/agent-voice.md
@@ -69,8 +69,7 @@ The Voice Agent can also use MCP tools.
 | Tool | Description |
 |---|---|
 | `getDateAndTimeTool` | Get current time in specified timezone |
-| DuckDuckGo `search` | Web search |
-| DuckDuckGo `fetch_content` | Fetch full web page content |
+| AgentCore Web Search | Web search and page content retrieval |
 | AgentCore MCP tools | Document search, graph traversal, etc. |
 
 ---

--- a/docs/src/content/docs/en/agent.md
+++ b/docs/src/content/docs/en/agent.md
@@ -9,9 +9,9 @@ This project consists of 3 independent AI agents. Each agent is built on the [St
 
 | Agent | Role | Model | Interface |
 |---|---|---|---|
-| **IDP Agent** | Document analysis, search, artifact generation | Claude Opus 4.6 | HTTP streaming |
+| **IDP Agent** | Document analysis, search, artifact generation | Claude Opus 4.8 (default) | HTTP streaming |
 | **Voice Agent** | Real-time bidirectional voice conversation | Nova Sonic | WebSocket |
-| **Web Crawler Agent** | Web page crawling and content extraction | Claude Sonnet 4.6 | SQS trigger |
+| **Web Crawler Agent** | Web page crawling and content extraction | Claude Sonnet 5 | SQS trigger |
 
 ## Common Architecture
 

--- a/docs/src/content/docs/en/analysis.md
+++ b/docs/src/content/docs/en/analysis.md
@@ -23,8 +23,8 @@ Upstream Preprocessing (parallel)
   Segment Builder (merge all results → S3 segment JSON)
        ↓
   Segment Analyzer (ReAct Agent)
-  ├─ Documents/Images → Claude Sonnet 4.6 + image analysis tools
-  └─ Videos/Audio     → Claude Sonnet 4.6 + Pegasus video analysis tool
+  ├─ Documents/Images → Claude Sonnet 5 + image analysis tools
+  └─ Videos/Audio     → Claude Sonnet 5 + Pegasus video analysis tool
        ↓
   Analysis Finalizer → SQS → LanceDB Writer
        ↓
@@ -110,13 +110,13 @@ The Segment Analyzer uses an **iterative question-answer** approach. After revie
 Agent reviews context
   → "I need to identify the document type"
     → analyze_image("What is the type and structure of this document?")
-      → Claude Sonnet 4.6 examines the image and responds
+      → Claude Sonnet 5 examines the image and responds
   → "There's a table that needs detailed analysis"
     → analyze_image("Extract the table structure and data")
-      → Claude Sonnet 4.6 responds
+      → Claude Sonnet 5 responds
   → "I should check the technical drawing dimensions"
     → analyze_image("What are the dimensions and specifications shown?")
-      → Claude Sonnet 4.6 responds
+      → Claude Sonnet 5 responds
   → Synthesize all results into final analysis
 ```
 
@@ -138,14 +138,14 @@ The agent automatically adjusts analysis depth based on content complexity.
 
 | Model | Purpose |
 |-------|---------|
-| **Claude Sonnet 4.6** | ReAct agent (reasoning + tool call decisions) |
-| **Claude Sonnet 4.6** (Vision) | Image analysis tool (processes image + question internally) |
+| **Claude Sonnet 5** | ReAct agent (reasoning + tool call decisions) |
+| **Claude Sonnet 5** (Vision) | Image analysis tool (processes image + question internally) |
 
 ### Available Tools
 
 #### analyze_image
 
-Analyzes document images by asking specific questions. Uses Claude Sonnet 4.6's Vision capability to directly examine images and provide answers.
+Analyzes document images by asking specific questions. Uses Claude Sonnet 5's Vision capability to directly examine images and provide answers.
 
 ```python
 @tool
@@ -202,7 +202,7 @@ Final synthesis → Consolidate all tool responses into structured analysis
 
 | Model | Purpose |
 |-------|---------|
-| **Claude Sonnet 4.6** | ReAct agent (reasoning + tool call decisions) |
+| **Claude Sonnet 5** | ReAct agent (reasoning + tool call decisions) |
 | **TwelveLabs Pegasus 1.2** | Video analysis tool (analyzes video directly internally) |
 
 ### Available Tools
@@ -268,8 +268,8 @@ Final synthesis → Combine Transcribe + Pegasus responses into timeline-based a
 | Segment Type | `PAGE` | `CHAPTER`, `VIDEO`, `AUDIO` |
 | Input Data | Image URI | Video URI + timecodes |
 | Preprocessing Data | OCR + BDA (optional) + PDF text | Transcribe + BDA (optional) |
-| Agent Model | Claude Sonnet 4.6 | Claude Sonnet 4.6 |
-| Analysis Tool Model | Claude Sonnet 4.6 (Vision) | TwelveLabs Pegasus 1.2 |
+| Agent Model | Claude Sonnet 5 | Claude Sonnet 5 |
+| Analysis Tool Model | Claude Sonnet 5 (Vision) | TwelveLabs Pegasus 1.2 |
 | Tools | `analyze_image`, `rotate_image` | `analyze_video` |
 | Analysis Focus | Text, tables, diagrams, layout | Actions, scenes, speech, visual events |
 

--- a/docs/src/content/docs/en/features.md
+++ b/docs/src/content/docs/en/features.md
@@ -100,10 +100,24 @@ A conversational AI interface powered by Bedrock Agent Core. IDP Agent and Resea
 
 ### Chat Features
 
-- Streaming responses with real-time tool usage display
+- Streaming responses with real-time tool usage display (typing buffering for smooth rendering)
+- Stop mid-response (cancel in-progress generation)
 - Image/document attachments (multi-modal input)
 - Markdown rendering and code highlighting
 - Session management (create / rename / delete, conversation history preserved)
+
+### Model Selection
+
+Pick the model and reasoning effort per turn.
+
+- Model list loaded from an SSM-backed catalog (add/remove without redeploy)
+- Reasoning effort (low/medium/high) — for models that support it
+- Changing the model starts a new chat; the last-used model per session is remembered (this browser only)
+
+### Inline Visualization and Questions
+
+- **Inline charts**: numeric answers rendered as chart cards (horizontal bar / compare / timeline / donut / stacked / scatter)
+- **Question cards**: the agent presents structured questions (single / multi / free-text) as cards, and the user's choice is applied on the next turn
 
 ### Hybrid Search
 
@@ -125,10 +139,12 @@ Create custom agents per project for specialized analysis.
 
 | Tool | Description |
 |------|-------------|
-| search_documents | Hybrid search across project documents |
+| summarize / graph_traverse / graph_keyword | Hybrid search and graph traversal over project documents |
+| search_datasets / describe_dataset / run_sql | Structured data (Excel/CSV) Text2SQL querying |
+| create/edit_document, extract_text/tables | Generate documents (PDF/DOCX/PPTX) and extract text/tables |
 | save/load/edit_markdown | Create and edit markdown files |
-| create_pdf, extract_pdf_text/tables | Generate PDFs and extract text/tables |
-| create_docx, extract_docx_text/tables | Generate Word documents and extract text/tables |
+| render_chart | Render inline chart cards |
+| ask_user | Show question cards |
 | generate_image | AI image generation |
 | code_interpreter | Python code execution |
 

--- a/docs/src/content/docs/en/preprocessing.md
+++ b/docs/src/content/docs/en/preprocessing.md
@@ -40,6 +40,9 @@ Type Detection Lambda
 | Text | `.txt` `.md` | - | - | - | A | - |
 | Web | `.webreq` | - | - | - | - | A |
 | CAD | `.dxf` | - | - | - | A | - |
+| Structured data | `.xlsx` `.xls` `.csv` `.tsv` | - | - | - | - | - |
+
+> Structured data (Excel/CSV) takes a **dedicated dataset branch** (validate → Parquet conversion → reference doc → DATASET# record) instead of the document analysis pipeline. See the "Structured Data" detail flow below.
 
 - **A** (Automatic): Enabled by default (runs automatically)
 - **O** (Optional): User enables per document at upload time
@@ -300,6 +303,31 @@ Type Detection
 | Images | Per-layout PNG (`format-parser/slides/layout_XXXX.png`) |
 | Automatic Preprocessing | Format Parser |
 | Extracted Entities | TEXT, MTEXT, ATTRIB, DIMENSION + layer/block metadata |
+
+### Structured Data (XLSX/XLS/CSV/TSV)
+
+Excel/CSV are processed as **structured datasets** for Text2SQL querying instead of document analysis. When Type Detection routes them as `processing_type='dataset'`, the IsDataset choice at the start of Step Functions takes a dedicated branch.
+
+```
+XLSX/CSV upload
+  ↓
+Type Detection (processing_type='dataset')
+  └─ Workflow Queue → Step Functions → IsDataset choice
+      └─ DatasetProcess (single Lambda)
+          ├─ 1. Validate: confirm it's tabular (merged cells/images/charts → reject)
+          ├─ 2. Convert each sheet to Parquet (snake_case column normalization)
+          ├─ 3. Generate reference doc (Bedrock: schema/samples/query examples)
+          └─ 4. Record DATASET# + index into the catalog (for search)
+```
+
+| Item | Value |
+|------|-------|
+| Output | `.../documents/{document_id}/dataset/{dataset_id}.parquet` + `.txt` (reference) |
+| Identifier | `{document_id}` (single sheet) or `{document_id}__{sheet_index}` (multi-sheet) |
+| Querying | SQL from chat via Data MCP (`search_datasets` / `describe_dataset` / `run_sql`) |
+| Validation failure | Workflow status `needs_user_fix` + reason (asks the user to clean up and re-upload) |
+
+> In multi-sheet workbooks each sheet becomes its own DATASET#. Unnamed index columns and mixed-type columns are normalized automatically, so no data is lost during conversion.
 
 ---
 

--- a/docs/src/content/docs/ja/agent-idp.md
+++ b/docs/src/content/docs/ja/agent-idp.md
@@ -14,12 +14,21 @@ IDP Agentは、ユーザーとの会話を通じて文書を検索・分析し�
 AgentCore Runtime（HTTPストリーミング）
   │
   ▼
-Strands Agent（Claude Opus 4.6）
+Strands Agent（Claude Opus 4.8、デフォルト）
   ├─ 1. 意図の把握
   ├─ 2. 実行計画の策定
   ├─ 3. スキルロード → ツール呼び出し → 結果収集
   └─ 4. 引用付き最終回答の生成
 ```
+
+### モデル選択
+
+ユーザーはチャット入力欄で、ターンごとに使用するモデルと推論（reasoning）強度を選択できます。
+
+- 選択可能なモデルは SSM パラメータ（`/idp-v2/chat/models`）に定義されたカタログからランタイムに読み込まれます。モデルの追加/削除は再デプロイなしにパラメータの編集だけで反映されます。
+- エージェントはリクエストされた `model_id` をカタログの許可リストで検証します（フロントの選択 UI はセキュリティ境界ではありません）。許可されていないモデルはデフォルトモデルにフォールバックします。
+- 推論強度（low/medium/high）は、最終的に確定したモデルが対応している場合のみ `output_config.effort` として渡されます。
+- モデルを変更すると新しい会話が開始され、1 つのセッションに複数モデルの応答が混在しません。
 
 ---
 
@@ -29,7 +38,8 @@ Strands Agent（Claude Opus 4.6）
 
 | スキル | 用途 | 使用ツール |
 |---|---|---|
-| **search** | 文書検索 + Web検索戦略 | Search MCP (graph_traverse, graph_keyword)、DuckDuckGo |
+| **search** | 文書検索 + Web検索戦略 | Search MCP (graph_traverse, graph_keyword)、AgentCore Web Search |
+| **dataset** | 構造化データ（Excel/CSV）Text2SQL クエリ | Data MCP (search_datasets, describe_dataset, run_sql) |
 | **docx** | Word文書の作成/編集 | Code Interpreter（python-docx） |
 | **xlsx** | Excelスプレッドシートの作成/編集 | Code Interpreter（openpyxl） |
 | **pptx** | PowerPointの作成/編集 | Code Interpreter（python-pptx） |
@@ -79,6 +89,16 @@ AgentCore Gatewayを通じてアクセスするMCPツールです。
 | `create_document` | PDF/DOCX/PPTXの作成 |
 | `edit_document` | 既存文書の編集 |
 
+### Data MCP（構造化データ Text2SQL）
+
+Excel/CSV から変換された Parquet データセットを SQL でクエリします。正確な集計・フィルタ・ソートが必要な構造化データに使用します。
+
+| ツール | 説明 |
+|---|---|
+| `search_datasets` | プロジェクト内のデータセットを名前/説明ベースでハイブリッド検索 |
+| `describe_dataset` | データセットのスキーマ・サンプル・クエリ例（リファレンス文書）の取得 |
+| `run_sql` | DuckDB で Parquet データセットに read-only SQL を実行 |
+
 ### その他のMCP
 
 | MCP | ツール | 説明 |
@@ -89,6 +109,21 @@ AgentCore Gatewayを通じてアクセスするMCPツールです。
 | MD MCP | `load_markdown` | Markdownの読み込み |
 | MD MCP | `save_markdown` | Markdownの保存 |
 | MD MCP | `edit_markdown` | Markdownの編集 |
+
+---
+
+## ローカルツール
+
+Gateway を経由せず、エージェントプロセス内で直接実行されるツールです。
+
+| ツール | 説明 |
+|---|---|
+| `render_chart` | 応答にインラインチャートカードをレンダリング（hbar / compare / timeline / donut / stacked / scatter）。直前のツール結果の実数値のみ使用 |
+| `ask_user` | 構造化された選択質問カード（単一/複数/自由入力）を表示。ユーザーの選択は次のメッセージとして渡され、次のターンで反映 |
+| `generate_image` | AI画像生成 |
+| `code_interpreter` | 隔離された Python サンドボックス実行（下記参照） |
+
+`render_chart` と `ask_user` の結果は、フロントエンドでプレーンテキストの代わりに専用 UI カードとしてレンダリングされます。
 
 ---
 

--- a/docs/src/content/docs/ja/agent-voice.md
+++ b/docs/src/content/docs/ja/agent-voice.md
@@ -69,8 +69,7 @@ Voice AgentもMCPツールを使用できます。
 | ツール | 説明 |
 |---|---|
 | `getDateAndTimeTool` | 指定タイムゾーンの現在時刻を取得 |
-| DuckDuckGo `search` | Web検索 |
-| DuckDuckGo `fetch_content` | Webページ全文取得 |
+| AgentCore Web Search | Web検索およびページコンテンツ取得 |
 | AgentCore MCPツール | 文書検索、グラフ探索など |
 
 ---

--- a/docs/src/content/docs/ja/agent.md
+++ b/docs/src/content/docs/ja/agent.md
@@ -9,9 +9,9 @@ description: "Strands SDKベースのAIエージェントアーキテクチャ�
 
 | エージェント | 役割 | モデル | インターフェース |
 |---|---|---|---|
-| **IDP Agent** | 文書分析、検索、アーティファクト生成 | Claude Opus 4.6 | HTTPストリーミング |
+| **IDP Agent** | 文書分析、検索、アーティファクト生成 | Claude Opus 4.8（デフォルト） | HTTPストリーミング |
 | **Voice Agent** | リアルタイム双方向音声会話 | Nova Sonic | WebSocket |
-| **Web Crawler Agent** | Webページクローリングとコンテンツ抽出 | Claude Sonnet 4.6 | SQSトリガー |
+| **Web Crawler Agent** | Webページクローリングとコンテンツ抽出 | Claude Sonnet 5 | SQSトリガー |
 
 ## 共通アーキテクチャ
 

--- a/docs/src/content/docs/ja/analysis.md
+++ b/docs/src/content/docs/ja/analysis.md
@@ -23,8 +23,8 @@ Segment Analyzerは、Strands SDKベースの**ReAct（Reasoning + Acting）エ�
   Segment Builder（全結果をマージ → S3セグメントJSON）
        ↓
   Segment Analyzer (ReAct Agent)
-  ├─ 文書/画像 → Claude Sonnet 4.6 + 画像分析ツール
-  └─ 映像/音声 → Claude Sonnet 4.6 + Pegasus映像分析ツール
+  ├─ 文書/画像 → Claude Sonnet 5 + 画像分析ツール
+  └─ 映像/音声 → Claude Sonnet 5 + Pegasus映像分析ツール
        ↓
   Analysis Finalizer → SQS → LanceDB Writer
        ↓
@@ -110,13 +110,13 @@ Segment Analyzerは**反復的質問-回答**方式で分析します。エー�
 エージェントがコンテキスト確認
   → 「この文書のタイプを確認する必要がある」
     → analyze_image("この文書のタイプと構造は？")を呼び出し
-      → Claude Sonnet 4.6が画像を見て回答
+      → Claude Sonnet 5が画像を見て回答
   → 「テーブルがあるので詳しく分析する必要がある」
     → analyze_image("テーブルの構造とデータを抽出して")を呼び出し
-      → Claude Sonnet 4.6が回答
+      → Claude Sonnet 5が回答
   → 「技術図面の寸法を確認する必要がある」
     → analyze_image("図面に表示された寸法と仕様は？")を呼び出し
-      → Claude Sonnet 4.6が回答
+      → Claude Sonnet 5が回答
   → 全結果を統合して最終分析を作成
 ```
 
@@ -138,14 +138,14 @@ Segment Analyzerは**反復的質問-回答**方式で分析します。エー�
 
 | モデル | 用途 |
 |--------|------|
-| **Claude Sonnet 4.6** | ReActエージェント（推論 + ツール呼び出し判断） |
-| **Claude Sonnet 4.6**（Vision） | 画像分析ツール（ツール内部で画像と質問を処理） |
+| **Claude Sonnet 5** | ReActエージェント（推論 + ツール呼び出し判断） |
+| **Claude Sonnet 5**（Vision） | 画像分析ツール（ツール内部で画像と質問を処理） |
 
 ### 使用ツール
 
 #### analyze_image
 
-文書画像に対して特定の質問を投げかけて分析します。Claude Sonnet 4.6のVision機能を使用して画像を直接確認し回答します。
+文書画像に対して特定の質問を投げかけて分析します。Claude Sonnet 5のVision機能を使用して画像を直接確認し回答します。
 
 ```python
 @tool
@@ -202,7 +202,7 @@ def rotate_image(degrees: int) -> str:
 
 | モデル | 用途 |
 |--------|------|
-| **Claude Sonnet 4.6** | ReActエージェント（推論 + ツール呼び出し判断） |
+| **Claude Sonnet 5** | ReActエージェント（推論 + ツール呼び出し判断） |
 | **TwelveLabs Pegasus 1.2** | 映像分析ツール（ツール内部で映像を直接分析） |
 
 ### 使用ツール
@@ -268,8 +268,8 @@ PegasusはS3の映像ファイルを直接分析し、BDAが抽出したチャ�
 | セグメントタイプ | `PAGE` | `CHAPTER`, `VIDEO`, `AUDIO` |
 | 入力データ | 画像URI | 映像URI + タイムコード |
 | 前処理データ | OCR + BDA（オプション） + PDFテキスト | Transcribe + BDA（オプション） |
-| エージェントモデル | Claude Sonnet 4.6 | Claude Sonnet 4.6 |
-| 分析ツールモデル | Claude Sonnet 4.6（Vision） | TwelveLabs Pegasus 1.2 |
+| エージェントモデル | Claude Sonnet 5 | Claude Sonnet 5 |
+| 分析ツールモデル | Claude Sonnet 5（Vision） | TwelveLabs Pegasus 1.2 |
 | ツール | `analyze_image`, `rotate_image` | `analyze_video` |
 | 分析フォーカス | テキスト、テーブル、ダイアグラム、レイアウト | 動作、シーン、音声、視覚的イベント |
 

--- a/docs/src/content/docs/ja/features.md
+++ b/docs/src/content/docs/ja/features.md
@@ -100,10 +100,24 @@ Bedrock Agent Coreベースの対話型AIインターフェースです。IDP Ag
 
 ### チャット機能
 
-- ストリーミング応答およびツール使用過程のリアルタイム表示
+- ストリーミング応答およびツール使用過程のリアルタイム表示（タイピングバッファリングで滑らかなレンダリング）
+- 応答の途中停止（進行中の生成をキャンセル）
 - 画像/文書添付（マルチモーダル入力）
 - マークダウンレンダリングおよびコードハイライト
 - セッション管理（作成/名前変更/削除、会話履歴保存）
+
+### モデル選択
+
+ターンごとに使用するモデルと推論（reasoning）強度を選択します。
+
+- モデル一覧は SSM パラメータベースのカタログから読み込み（再デプロイなしで追加/削除）
+- 推論強度（low/medium/high）の調整 — 対応モデルのみ
+- モデル変更時は新しい会話を開始、セッションごとの最後に使用したモデルを記憶（このブラウザのみ）
+
+### インライン可視化と質問
+
+- **インラインチャート**: 数値回答をチャートカードでレンダリング（横棒 / 比較 / タイムライン / ドーナツ / 積み上げ / 散布図）
+- **質問カード**: エージェントが構造化された質問（単一/複数/自由入力）をカードで提示し、ユーザーの選択が次のターンに反映
 
 ### ハイブリッド検索
 
@@ -125,10 +139,12 @@ Bedrock Agent Coreベースの対話型AIインターフェースです。IDP Ag
 
 | ツール | 説明 |
 |--------|------|
-| search_documents | プロジェクト文書のハイブリッド検索 |
+| summarize / graph_traverse / graph_keyword | プロジェクト文書のハイブリッド検索・グラフ探索 |
+| search_datasets / describe_dataset / run_sql | 構造化データ（Excel/CSV）Text2SQL クエリ |
+| create/edit_document, extract_text/tables | 文書（PDF/DOCX/PPTX）生成およびテキスト/テーブル抽出 |
 | save/load/edit_markdown | マークダウンファイルの作成・編集 |
-| create_pdf, extract_pdf_text/tables | PDF生成およびテキスト/テーブル抽出 |
-| create_docx, extract_docx_text/tables | Word文書生成およびテキスト/テーブル抽出 |
+| render_chart | インラインチャートカードのレンダリング |
+| ask_user | 質問カードの表示 |
 | generate_image | AI画像生成 |
 | code_interpreter | Pythonコード実行 |
 

--- a/docs/src/content/docs/ja/preprocessing.md
+++ b/docs/src/content/docs/ja/preprocessing.md
@@ -40,6 +40,9 @@ Type Detection Lambda
 | テキスト | `.txt` `.md` | - | - | - | A | - |
 | ウェブ | `.webreq` | - | - | - | - | A |
 | CAD | `.dxf` | - | - | - | A | - |
+| 構造化データ | `.xlsx` `.xls` `.csv` `.tsv` | - | - | - | - | - |
+
+> 構造化データ（Excel/CSV）は、文書分析パイプラインではなく**専用の dataset ブランチ**（検証 → Parquet 変換 → リファレンス文書 → DATASET# 記録）を通ります。下記「構造化データ」の詳細フローを参照。
 
 - **A**（Automatic）：デフォルトで有効（自動実行）
 - **O**（Optional）：文書アップロード時にユーザーが選択的に有効化
@@ -300,6 +303,31 @@ Type Detection
 | 画像 | レイアウトごとのPNG（`format-parser/slides/layout_XXXX.png`） |
 | 自動前処理 | Format Parser |
 | 抽出エンティティ | TEXT、MTEXT、ATTRIB、DIMENSION + レイヤー/ブロックメタデータ |
+
+### 構造化データ（XLSX/XLS/CSV/TSV）
+
+Excel/CSV は文書分析ではなく、Text2SQL クエリ用の**構造化データセット**として処理されます。Type Detection が `processing_type='dataset'` としてルーティングすると、Step Functions 開始点の IsDataset 分岐で専用ブランチを通ります。
+
+```
+XLSX/CSV アップロード
+  ↓
+Type Detection（processing_type='dataset'）
+  └─ Workflow Queue → Step Functions → IsDataset 分岐
+      └─ DatasetProcess（単一 Lambda）
+          ├─ 1. 検証：表形式か確認（結合セル/画像/チャート → reject）
+          ├─ 2. シートごとに Parquet 変換（カラム名 snake_case 正規化）
+          ├─ 3. リファレンス文書生成（Bedrock：スキーマ/サンプル/クエリ例）
+          └─ 4. DATASET# 記録 + カタログインデックス（検索用）
+```
+
+| 項目 | 値 |
+|------|-----|
+| 出力 | `.../documents/{document_id}/dataset/{dataset_id}.parquet` + `.txt`（リファレンス） |
+| 識別子 | `{document_id}`（単一シート）または `{document_id}__{sheet_index}`（複数シート） |
+| クエリ | Data MCP（`search_datasets` / `describe_dataset` / `run_sql`）でチャットから SQL クエリ |
+| 検証失敗 | ワークフロー状態 `needs_user_fix` + 理由（表形式に整えて再アップロードするよう案内） |
+
+> 複数シートのブックでは各シートが個別の DATASET# として処理されます。無名のインデックス列や混在型カラムは自動的に正規化され、変換時にデータが失われません。
 
 ---
 

--- a/docs/src/content/docs/ko/agent-idp.md
+++ b/docs/src/content/docs/ko/agent-idp.md
@@ -14,12 +14,21 @@ IDP Agent는 사용자와의 대화를 통해 문서를 검색하고 분석하�
 AgentCore Runtime (HTTP 스트리밍)
   │
   ▼
-Strands Agent (Claude Opus 4.6)
+Strands Agent (Claude Opus 4.8, 기본값)
   ├─ 1. 의도 파악
   ├─ 2. 실행 계획 수립
   ├─ 3. 스킬 로딩 → 도구 호출 → 결과 수집
   └─ 4. 인용 포함 최종 응답 생성
 ```
+
+### 모델 선택
+
+사용자는 채팅 입력창에서 턴마다 사용할 모델과 추론(reasoning) 강도를 선택할 수 있습니다.
+
+- 선택 가능한 모델은 SSM 파라미터(`/idp-v2/chat/models`)에 정의된 카탈로그에서 런타임에 로드됩니다. 모델 추가/제거는 재배포 없이 파라미터 수정만으로 반영됩니다.
+- 에이전트는 요청된 `model_id`를 카탈로그 허용 목록으로 검증합니다(프론트 선택 UI는 보안 경계가 아님). 허용되지 않은 모델은 기본 모델로 대체됩니다.
+- 추론 강도(low/medium/high)는 최종 확정된 모델이 지원할 때만 `output_config.effort`로 전달됩니다.
+- 모델을 변경하면 새 대화가 시작되어 한 세션에 여러 모델 응답이 섞이지 않습니다.
 
 ---
 
@@ -29,7 +38,8 @@ Strands Agent (Claude Opus 4.6)
 
 | 스킬 | 용도 | 사용 도구 |
 |---|---|---|
-| **search** | 문서 검색 + 웹 검색 전략 | Search MCP (graph_traverse, graph_keyword), DuckDuckGo |
+| **search** | 문서 검색 + 웹 검색 전략 | Search MCP (graph_traverse, graph_keyword), AgentCore Web Search |
+| **dataset** | 정형 데이터(엑셀/CSV) Text2SQL 질의 | Data MCP (search_datasets, describe_dataset, run_sql) |
 | **docx** | Word 문서 생성/편집 | Code Interpreter (python-docx) |
 | **xlsx** | Excel 스프레드시트 생성/편집 | Code Interpreter (openpyxl) |
 | **pptx** | PowerPoint 생성/편집 | Code Interpreter (python-pptx) |
@@ -79,6 +89,16 @@ AgentCore Gateway를 통해 접근하는 MCP 도구입니다.
 | `create_document` | PDF/DOCX/PPTX 생성 |
 | `edit_document` | 기존 문서 편집 |
 
+### Data MCP (정형 데이터 Text2SQL)
+
+엑셀/CSV에서 변환된 Parquet 데이터셋을 SQL로 질의합니다. 정확한 집계·필터·정렬이 필요한 정형 데이터에 사용합니다.
+
+| 도구 | 설명 |
+|---|---|
+| `search_datasets` | 프로젝트 내 데이터셋을 이름/설명 기반으로 하이브리드 검색 |
+| `describe_dataset` | 데이터셋의 스키마·샘플·쿼리 예시(레퍼런스 문서) 조회 |
+| `run_sql` | DuckDB로 Parquet 데이터셋에 read-only SQL 실행 |
+
 ### 기타 MCP
 
 | MCP | 도구 | 설명 |
@@ -89,6 +109,21 @@ AgentCore Gateway를 통해 접근하는 MCP 도구입니다.
 | MD MCP | `load_markdown` | 마크다운 로드 |
 | MD MCP | `save_markdown` | 마크다운 저장 |
 | MD MCP | `edit_markdown` | 마크다운 편집 |
+
+---
+
+## 로컬 도구
+
+Gateway를 거치지 않고 에이전트 프로세스에서 직접 실행되는 도구입니다.
+
+| 도구 | 설명 |
+|---|---|
+| `render_chart` | 응답에 인라인 차트 카드를 렌더링 (hbar / compare / timeline / donut / stacked / scatter). 직전 도구 결과의 실제 수치만 사용 |
+| `ask_user` | 구조화된 선택 질문 카드(단일/복수/자유 입력)를 표시. 사용자의 선택은 다음 메시지로 전달되어 다음 턴에 반영 |
+| `generate_image` | AI 이미지 생성 |
+| `code_interpreter` | 격리된 Python 샌드박스 실행 (아래 참고) |
+
+`render_chart`와 `ask_user`의 결과는 프론트엔드에서 일반 텍스트 대신 전용 UI 카드로 렌더링됩니다.
 
 ---
 

--- a/docs/src/content/docs/ko/agent-voice.md
+++ b/docs/src/content/docs/ko/agent-voice.md
@@ -69,8 +69,7 @@ Voice Agent도 MCP 도구를 사용할 수 있습니다.
 | 도구 | 설명 |
 |---|---|
 | `getDateAndTimeTool` | 지정 타임존의 현재 시간 조회 |
-| DuckDuckGo `search` | 웹 검색 |
-| DuckDuckGo `fetch_content` | 웹 페이지 전문 조회 |
+| AgentCore Web Search | 웹 검색 및 페이지 콘텐츠 조회 |
 | AgentCore MCP 도구 | 문서 검색, 그래프 탐색 등 |
 
 ---

--- a/docs/src/content/docs/ko/agent.md
+++ b/docs/src/content/docs/ko/agent.md
@@ -9,9 +9,9 @@ description: "Strands SDK 기반 AI 에이전트 아키텍처와 역할"
 
 | 에이전트 | 역할 | 모델 | 인터페이스 |
 |---|---|---|---|
-| **IDP Agent** | 문서 분석, 검색, 아티팩트 생성 | Claude Opus 4.6 | HTTP 스트리밍 |
+| **IDP Agent** | 문서 분석, 검색, 아티팩트 생성 | Claude Opus 4.8 (기본값) | HTTP 스트리밍 |
 | **Voice Agent** | 실시간 양방향 음성 대화 | Nova Sonic | WebSocket |
-| **Web Crawler Agent** | 웹 페이지 크롤링 및 콘텐츠 추출 | Claude Sonnet 4.6 | SQS 트리거 |
+| **Web Crawler Agent** | 웹 페이지 크롤링 및 콘텐츠 추출 | Claude Sonnet 5 | SQS 트리거 |
 
 ## 공통 아키텍처
 

--- a/docs/src/content/docs/ko/analysis.md
+++ b/docs/src/content/docs/ko/analysis.md
@@ -23,8 +23,8 @@ Segment Analyzer는 Strands SDK 기반의 **ReAct(Reasoning + Acting) 에이전�
   Segment Builder (모든 결과 병합 → S3 세그먼트 JSON)
        ↓
   Segment Analyzer (ReAct Agent)
-  ├─ 문서/이미지 → Claude Sonnet 4.6 + 이미지 분석 도구
-  └─ 영상/음성   → Claude Sonnet 4.6 + Pegasus 영상 분석 도구
+  ├─ 문서/이미지 → Claude Sonnet 5 + 이미지 분석 도구
+  └─ 영상/음성   → Claude Sonnet 5 + Pegasus 영상 분석 도구
        ↓
   Analysis Finalizer → SQS → LanceDB Writer
        ↓
@@ -110,13 +110,13 @@ Segment Analyzer는 **반복적 질문-응답** 방식으로 분석합니다. �
 에이전트가 컨텍스트 확인
   → "이 문서가 어떤 유형인지 확인해야겠다"
     → analyze_image("이 문서의 유형과 구조는?") 호출
-      → Claude Sonnet 4.6이 이미지를 보고 응답
+      → Claude Sonnet 5이 이미지를 보고 응답
   → "테이블이 있으니 자세히 분석해야겠다"
     → analyze_image("테이블의 구조와 데이터를 추출해줘") 호출
-      → Claude Sonnet 4.6이 응답
+      → Claude Sonnet 5이 응답
   → "기술 도면의 치수를 확인해야겠다"
     → analyze_image("도면에 표시된 치수와 사양은?") 호출
-      → Claude Sonnet 4.6이 응답
+      → Claude Sonnet 5이 응답
   → 모든 결과 종합하여 최종 분석 작성
 ```
 
@@ -138,14 +138,14 @@ Segment Analyzer는 **반복적 질문-응답** 방식으로 분석합니다. �
 
 | 모델 | 용도 |
 |------|------|
-| **Claude Sonnet 4.6** | ReAct 에이전트 (추론 + 도구 호출 결정) |
-| **Claude Sonnet 4.6** (Vision) | 이미지 분석 도구 (도구 내부에서 이미지와 질문 처리) |
+| **Claude Sonnet 5** | ReAct 에이전트 (추론 + 도구 호출 결정) |
+| **Claude Sonnet 5** (Vision) | 이미지 분석 도구 (도구 내부에서 이미지와 질문 처리) |
 
 ### 사용 도구
 
 #### analyze_image
 
-문서 이미지에 대해 특정 질문을 던져 분석합니다. Claude Sonnet 4.6의 Vision 기능을 사용하여 이미지를 직접 확인하고 답변합니다.
+문서 이미지에 대해 특정 질문을 던져 분석합니다. Claude Sonnet 5의 Vision 기능을 사용하여 이미지를 직접 확인하고 답변합니다.
 
 ```python
 @tool
@@ -202,7 +202,7 @@ def rotate_image(degrees: int) -> str:
 
 | 모델 | 용도 |
 |------|------|
-| **Claude Sonnet 4.6** | ReAct 에이전트 (추론 + 도구 호출 결정) |
+| **Claude Sonnet 5** | ReAct 에이전트 (추론 + 도구 호출 결정) |
 | **TwelveLabs Pegasus 1.2** | 영상 분석 도구 (도구 내부에서 영상 직접 분석) |
 
 ### 사용 도구
@@ -268,8 +268,8 @@ Pegasus는 S3의 영상 파일을 직접 분석하며, BDA가 추출한 챕터 �
 | 세그먼트 유형 | `PAGE` | `CHAPTER`, `VIDEO`, `AUDIO` |
 | 입력 데이터 | 이미지 URI | 영상 URI + 타임코드 |
 | 전처리 데이터 | OCR + BDA(옵션) + PDF 텍스트 | Transcribe + BDA(옵션) |
-| 에이전트 모델 | Claude Sonnet 4.6 | Claude Sonnet 4.6 |
-| 분석 도구 모델 | Claude Sonnet 4.6 (Vision) | TwelveLabs Pegasus 1.2 |
+| 에이전트 모델 | Claude Sonnet 5 | Claude Sonnet 5 |
+| 분석 도구 모델 | Claude Sonnet 5 (Vision) | TwelveLabs Pegasus 1.2 |
 | 도구 | `analyze_image`, `rotate_image` | `analyze_video` |
 | 분석 초점 | 텍스트, 테이블, 다이어그램, 레이아웃 | 동작, 장면, 음성, 시각적 이벤트 |
 

--- a/docs/src/content/docs/ko/features.md
+++ b/docs/src/content/docs/ko/features.md
@@ -100,10 +100,24 @@ Bedrock Agent Core 기반의 대화형 AI 인터페이스입니다. IDP Agent와
 
 ### 대화 기능
 
-- 스트리밍 응답 및 도구 사용 과정 실시간 표시
+- 스트리밍 응답 및 도구 사용 과정 실시간 표시 (타이핑 버퍼링으로 부드러운 렌더링)
+- 응답 중 중지 (진행 중인 생성 취소)
 - 이미지/문서 첨부 (멀티모달 입력)
 - 마크다운 렌더링 및 코드 하이라이팅
 - 세션 관리 (생성/이름변경/삭제, 대화 이력 보존)
+
+### 모델 선택
+
+턴마다 사용할 모델과 추론(reasoning) 강도를 선택합니다.
+
+- 모델 목록은 SSM 파라미터 기반 카탈로그에서 로드 (재배포 없이 추가/제거)
+- 추론 강도(low/medium/high) 조절 — 지원 모델에 한함
+- 모델 변경 시 새 대화 시작, 세션별 마지막 사용 모델 기억 (이 브라우저 한정)
+
+### 인라인 시각화 및 질문
+
+- **인라인 차트**: 수치 응답을 차트 카드로 렌더링 (가로 막대 / 비교 / 타임라인 / 도넛 / 누적 / 산점도)
+- **선택 질문 카드**: 에이전트가 구조화된 질문(단일/복수/자유 입력)을 카드로 제시하고, 사용자의 선택이 다음 턴에 반영
 
 ### 하이브리드 검색
 
@@ -125,10 +139,12 @@ Bedrock Agent Core 기반의 대화형 AI 인터페이스입니다. IDP Agent와
 
 | 도구 | 설명 |
 |------|------|
-| search_documents | 프로젝트 문서 하이브리드 검색 |
+| summarize / graph_traverse / graph_keyword | 프로젝트 문서 하이브리드 검색 및 그래프 탐색 |
+| search_datasets / describe_dataset / run_sql | 정형 데이터(엑셀/CSV) Text2SQL 질의 |
+| create/edit_document, extract_text/tables | 문서(PDF/DOCX/PPTX) 생성 및 텍스트/테이블 추출 |
 | save/load/edit_markdown | 마크다운 파일 생성 및 편집 |
-| create_pdf, extract_pdf_text/tables | PDF 생성 및 텍스트/테이블 추출 |
-| create_docx, extract_docx_text/tables | Word 문서 생성 및 텍스트/테이블 추출 |
+| render_chart | 인라인 차트 카드 렌더링 |
+| ask_user | 선택 질문 카드 표시 |
 | generate_image | AI 이미지 생성 |
 | code_interpreter | Python 코드 실행 |
 

--- a/docs/src/content/docs/ko/preprocessing.md
+++ b/docs/src/content/docs/ko/preprocessing.md
@@ -40,6 +40,9 @@ Type Detection Lambda
 | 텍스트 | `.txt` `.md` | - | - | - | A | - |
 | 웹 | `.webreq` | - | - | - | - | A |
 | CAD | `.dxf` | - | - | - | A | - |
+| 정형 데이터 | `.xlsx` `.xls` `.csv` `.tsv` | - | - | - | - | - |
+
+> 정형 데이터(엑셀/CSV)는 문서 분석 파이프라인 대신 **전용 dataset 브랜치**(검증 → Parquet 변환 → 레퍼런스 문서 → DATASET# 기록)를 탑니다. 아래 "정형 데이터" 상세 흐름 참고.
 
 - **A** (Automatic): 기본 활성화 (자동 실행)
 - **O** (Optional): 문서 업로드 시 사용자가 선택적으로 활성화
@@ -300,6 +303,31 @@ Type Detection
 | 이미지 | 레이아웃별 PNG (`format-parser/slides/layout_XXXX.png`) |
 | 자동 전처리 | Format Parser |
 | 추출 항목 | TEXT, MTEXT, ATTRIB, DIMENSION 엔티티 + 레이어/블록 메타데이터 |
+
+### 정형 데이터 (XLSX/XLS/CSV/TSV)
+
+엑셀/CSV는 문서 분석 대신 Text2SQL 질의를 위한 **정형 데이터셋**으로 처리됩니다. Type Detection이 `processing_type='dataset'`으로 라우팅하면 Step Functions 시작점의 IsDataset 분기에서 전용 브랜치를 탑니다.
+
+```
+XLSX/CSV 업로드
+  ↓
+Type Detection (processing_type='dataset')
+  └─ Workflow Queue → Step Functions → IsDataset 분기
+      └─ DatasetProcess (단일 Lambda)
+          ├─ 1. 검증: 표 형태 여부 확인 (병합 셀/이미지/차트 → reject)
+          ├─ 2. 시트별 Parquet 변환 (컬럼명 snake_case 정규화)
+          ├─ 3. 레퍼런스 문서 생성 (Bedrock: 스키마/샘플/쿼리 예시)
+          └─ 4. DATASET# 기록 + 카탈로그 인덱싱 (검색용)
+```
+
+| 항목 | 값 |
+|------|-----|
+| 출력 | `.../documents/{document_id}/dataset/{dataset_id}.parquet` + `.txt` (레퍼런스) |
+| 식별자 | `{document_id}` (단일 시트) 또는 `{document_id}__{sheet_index}` (멀티 시트) |
+| 질의 | Data MCP (`search_datasets` / `describe_dataset` / `run_sql`)로 채팅에서 SQL 질의 |
+| 검증 실패 | 워크플로우 상태 `needs_user_fix` + 사유 (표 형태로 정리 후 재업로드 안내) |
+
+> 멀티 시트는 각 시트가 개별 DATASET#로 처리됩니다. 이름없는 인덱스 열이나 혼합 타입 컬럼은 자동 정규화되어 데이터 손실 없이 변환됩니다.
 
 ---
 

--- a/packages/common/constructs/src/core/user-identity.ts
+++ b/packages/common/constructs/src/core/user-identity.ts
@@ -355,7 +355,11 @@ export class UserIdentity extends Construct {
             location: { horizontal: 'CENTER', vertical: 'CENTER' },
           },
           global: {
-            colorSchemeMode: 'DARK',
+            // LIGHT: the form uses a light card background (f8fafc/f1f5f9), so
+            // the light color scheme applies the dark text colors defined in
+            // pageText/inputLabel. Under DARK the heading/label rendered nearly
+            // invisible against the light card.
+            colorSchemeMode: 'LIGHT',
             pageHeader: { enabled: false },
             pageFooter: { enabled: false },
             spacingDensity: 'REGULAR',


### PR DESCRIPTION
  - Add model selector, reasoning, Data MCP (Text2SQL), and render_chart/ask_user local tools to agent-idp
  - Add model selection, inline charts, question cards, and stop-response to features chat section
  - Add structured-data (Excel/CSV → Parquet) dataset branch to preprocessing
  - Update model versions (Opus 4.8 / Sonnet 5) in agent and analysis
  - Replace DuckDuckGo with AgentCore Web Search in agent-idp and agent-voice
  - Apply all changes across en/ko/ja
